### PR TITLE
fix: typo in shared_ptr chapter

### DIFF
--- a/documents/vol2-modern-features/ch01-smart-pointers/03-shared-ptr.md
+++ b/documents/vol2-modern-features/ch01-smart-pointers/03-shared-ptr.md
@@ -238,7 +238,7 @@ void session_demo() {
 }
 ```
 
-⚠️ 使用 `enable_shared_from_this` 有一个前提条件：对象必须已经被一个 `shared_ptr` 管理。如果你在栈上创建对象或用裸指针管理，调用 `shared_from_this()` 会导致未定义行为。此外，构造函数中不能调用 `shared_from_this()`——因为此时 `shared_ptr` 还没有完成构造。
+⚠️ 使用 `shared_from_this()` 有一个前提条件：对象必须已经被一个 `shared_ptr` 管理。如果你在栈上创建对象或用裸指针管理，调用 `shared_from_this()` 会导致未定义行为。此外，构造函数中不能调用 `shared_from_this()`——因为此时 `shared_ptr` 还没有完成构造。
 
 ## 常见误用与踩坑
 


### PR DESCRIPTION
**Brief**: Found this typo while I read through this chapter. I believe the author mean `shared_from_this`

https://en.cppreference.com/cpp/memory/enable_shared_from_this/shared_from_this
```shell
Exceptions
If shared_from_this is called on an object that is not previously shared by std::shared_ptr, std::bad_weak_ptr is thrown by the std::shared_ptr constructor.
```

@Charliechen114514 