### PR TITLE
Fix: 2 typos in variant section

### DIFF
--- a/documents/vol2-modern-features/ch04-type-safety/03-variant.md
+++ b/documents/vol2-modern-features/ch04-type-safety/03-variant.md
@@ -432,7 +432,7 @@ struct UnaryExpr {
 ```cpp
 std::cout << "sizeof(variant<int, double, string>): "
           << sizeof(std::variant<int, double, std::string>) << "\n";
-// 典型输出：32（64 位平台上，string 占 32 字节，int 和 double 各 8 字节）
+// 典型输出：40（64 位平台上，string 占 32 字节，int 占 4 字节, double 占 8 字节）
 std::cout << "sizeof(string): " << sizeof(std::string) << "\n";
 // 典型输出：32
 ```


### PR DESCRIPTION
**Brief**: Fix 2 typos in `std::variant` section.

1. `int` type usually takes `4` bytes on 64 bit architectures.
2. `std::variant<int, std::string>` would take `8 (sizeof(size_t)) + 32 (max(sizeof(int), sizeof(std::string))` storage space then.

Please refer to this for reproduction: https://godbolt.org/z/sbvEMW56G

@Charliechen114514