### PR TITLE
feat: dev style entrance before start new dev on content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,8 @@ QA 不替代正文，只负责解答常见分叉问题和高频误区。
 
 新增文章前请检查 frontmatter、索引、内部链接、代码块和翻译状态。本地质量命令和 CI workflow 应保持可对应：
 
+项目日常维护和网站迭代节奏见 [项目开发 / 网站迭代节奏](documents/community/dev/01-iteration-cadence.md)。
+
 - Markdown link check
 - Frontmatter validation
 - English coverage

--- a/README.en.md
+++ b/README.en.md
@@ -12,6 +12,7 @@
 
 ![C++](https://img.shields.io/badge/C%2B%2B-11%20%7C%2014%20%7C%2017%20%7C%2020%20%7C%2023-blue?logo=c%2B%2B)
 ![Release](https://img.shields.io/github/v/release/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP)
+![Tag](https://img.shields.io/github/v/tag/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP?sort=semver&label=tag)
 ![License](https://img.shields.io/github/license/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP)
 ![Build](https://img.shields.io/github/actions/workflow/status/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/deploy.yml?branch=main)
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ![C++](https://img.shields.io/badge/C%2B%2B-11%20%7C%2014%20%7C%2017%20%7C%2020%20%7C%2023-blue?logo=c%2B%2B)
 ![Release](https://img.shields.io/github/v/release/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP)
+![Tag](https://img.shields.io/github/v/tag/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP?sort=semver&label=tag)
 ![License](https://img.shields.io/github/license/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP)
 ![Build](https://img.shields.io/github/actions/workflow/status/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/deploy.yml?branch=main)
 

--- a/documents/community/dev/01-iteration-cadence.md
+++ b/documents/community/dev/01-iteration-cadence.md
@@ -1,0 +1,120 @@
+---
+title: "网站迭代节奏"
+description: "Tutorial_AwesomeModernCPP 的内容产出、站点维护、PR/Issue 处理和发版节奏"
+chapter: 1
+order: 1
+tags: ["工程实践"]
+---
+
+# 网站迭代节奏
+
+Tutorial_AwesomeModernCPP 的迭代以内容产出为主，版本号用于度量内容推进幅度。站点维护、PR 和 Issue 处理服务于主线内容，不反过来接管主线节奏。
+
+## 基本节拍
+
+维护者通常每 2 到 3 天进行一次轻量迭代。每轮只绑定一个主要目标：
+
+- 完成一组相关内容。
+- 修复一批影响阅读的问题。
+- 补齐某个章节的代码、链接或翻译。
+- 处理已经明确可行动的 PR 或 Issue。
+
+一轮迭代不追求覆盖所有方向。卷级路线、长期候选和远期主题继续放在 `todo/`，不要把单篇文章级临时想法拆成新的治理文件。
+
+## 单轮维护流程
+
+每轮维护按以下顺序推进：
+
+1. 查看当前 TODO 中的 P0/P1 目标，选定一个主要内容目标。
+2. 快速检查 Issue 和 PR，只处理明确可行动、影响当前版本或阻塞读者的问题。
+3. 完成本轮内容、示例代码、索引和必要的英文同步。
+4. 运行与改动范围匹配的质量检查。
+5. 如果变化对读者可感知，更新 changelog 或准备下一个版本条目。
+
+PR 和 Issue 每轮至少检查一次。紧急问题可以随时插队，例如站点无法构建、重要页面 404、示例代码严重误导读者、外部贡献需要快速反馈。
+
+## 版本节奏
+
+版本号描述变化幅度，而不是强行驱动写作节奏。
+
+- patch：修错、链接、站点修复、低风险文本修订。
+- minor：一个卷或专题明显推进，读者能感知新的学习路径或完整能力。
+- major：TODO 结构、站点架构或内容体系发生大调整。
+
+patch 可以按需发布。minor 通常以 2 到 4 周为一个观察窗口，只有当某个专题形成完整增量时再发布。major 应保持克制，避免频繁改变读者和贡献者的入口认知。
+
+## Tag 与 Release
+
+tag 和 GitHub Release 分开使用。tag 用来标记轻量维护节点，让读者通过 README 徽章感知项目确实在持续变化；GitHub Release 只用于读者值得专门关注的内容型版本。
+
+- patch 级修复可以只打 tag，不必创建 GitHub Release。
+- minor 级专题推进通常应创建 Release，并配套 changelog。
+- major 级结构调整必须创建 Release，并解释迁移影响。
+
+这样可以保留项目活跃度信号，同时避免 Release 轰炸。
+
+## 完成定义
+
+一次内容迭代完成时，应尽量满足以下条件：
+
+- 正文可以独立阅读，术语和标准版本标注清楚。
+- 相关卷首页、章节索引或导航入口已更新。
+- 文章中的示例代码可以编译，或明确说明平台和工具链限制。
+- 中文和英文关键页面保持同步；社区初刊和低优先级长文可延后翻译。
+- 内部链接可通过检查，生产构建可通过。
+
+如果本轮只做局部修复，可以只运行相关检查；如果准备发版，应运行完整发布前检查。
+
+## PR 和 Issue 处理
+
+Issue 负责可行动问题，Discussion 负责开放式学习讨论，PR 负责具体修改。
+
+处理优先级如下：
+
+1. 阻塞构建、部署或主要阅读路径的问题。
+2. 已有 PR 中清晰、低风险、容易合并的修复。
+3. 与当前迭代主题直接相关的内容建议。
+4. 可沉淀为 QA、附录或后续 TODO 的学习问题。
+
+学习问题不直接塞进 Issue 列表；高质量讨论可以整理为 FAQ、附录或正文链接。
+
+## Changelog 原则
+
+changelog 应写读者可感知的变化，而不是简单罗列文件数量。
+
+推荐记录：
+
+- 新增或完成了哪条学习路径。
+- 哪些示例现在可以运行或验证。
+- 哪些站点入口、搜索、导航、社区流程得到改善。
+- 哪些贡献者帮助修正了具体问题。
+
+文件数、行数和提交数可以作为辅助数据，但不应替代变化说明。
+
+## 常用检查
+
+日常迭代按改动范围选择检查：
+
+```bash
+pnpm check:links
+python3 scripts/validate_frontmatter.py
+python3 scripts/check_quality.py documents/
+python3 scripts/build_examples.py --host
+```
+
+发版前建议运行：
+
+```bash
+pnpm check:links
+pnpm build
+pnpm coverage:update
+python3 scripts/validate_frontmatter.py
+python3 scripts/check_quality.py documents/
+python3 scripts/build_examples.py --host
+```
+
+如果改动 STM32 示例，再运行：
+
+```bash
+python3 scripts/build_examples.py --stm32
+```

--- a/documents/community/dev/index.md
+++ b/documents/community/dev/index.md
@@ -1,0 +1,25 @@
+---
+title: "项目开发"
+description: "社区协作下的项目维护节奏、开发日志、发布治理和站点演进记录"
+---
+
+# 项目开发
+
+这里记录 Tutorial_AwesomeModernCPP 自身的开发、维护和发布节奏。它挂靠在社区区下，因为这些流程直接服务于内容协作、PR/Issue 处理和站点长期维护。
+
+本区不替代 `todo/`、`changelogs/` 或 `CONTRIBUTING.md`：
+
+- `todo/` 记录内容路线和卷级规划。
+- `changelogs/` 记录已经发布的版本变化。
+- `CONTRIBUTING.md` 记录投稿、审阅和质量规则。
+- `community/dev/` 记录维护者如何推进网站和内容迭代。
+
+## 开发记录
+
+<ChapterNav variant="main">
+  <ChapterLink num="1" href="01-iteration-cadence">网站迭代节奏</ChapterLink>
+</ChapterNav>
+
+## 使用原则
+
+项目开发区优先沉淀长期有效的维护方法，而不是临时任务清单。短期任务仍进入对应卷级 TODO，版本变更仍进入 changelog。

--- a/documents/community/index.md
+++ b/documents/community/index.md
@@ -14,6 +14,7 @@ description: "社区来稿、初刊文章与已审阅收录内容"
 <ChapterNav variant="main">
   <ChapterLink num="1" href="incoming/">社区来稿初刊</ChapterLink>
   <ChapterLink num="2" href="articles/">已审阅收录</ChapterLink>
+  <ChapterLink num="3" href="dev/">项目开发</ChapterLink>
 </ChapterNav>
 
 ## 流转方式
@@ -55,3 +56,5 @@ description: "社区来稿、初刊文章与已审阅收录内容"
 - 作者同意公开展示，并允许维护者进行必要编辑。
 
 学习问题、路线讨论和开放式建议请优先使用 GitHub Discussions；明确的内容提案或投稿主题可以使用 GitHub Issue。
+
+项目自身的维护节奏、站点迭代和发布度量记录在 [项目开发](dev/) 中。

--- a/documents/en/community/dev/01-iteration-cadence.md
+++ b/documents/en/community/dev/01-iteration-cadence.md
@@ -1,0 +1,120 @@
+---
+title: "Site Iteration Cadence"
+description: "Content production, site maintenance, PR/Issue handling, and release cadence for Tutorial_AwesomeModernCPP"
+chapter: 1
+order: 1
+tags: ["工程实践"]
+---
+
+# Site Iteration Cadence
+
+Tutorial_AwesomeModernCPP is driven primarily by content production. Version numbers measure the size of content progress. Site maintenance, PRs, and Issues support the main content path instead of taking it over.
+
+## Basic Rhythm
+
+Maintainers usually run a lightweight iteration every 2 to 3 days. Each iteration should have one main goal:
+
+- Finish a related group of content.
+- Fix a batch of reading problems.
+- Complete code, links, or translations for a chapter.
+- Handle clearly actionable PRs or Issues.
+
+One iteration does not need to cover every direction. Volume roadmaps, long-term candidates, and future themes remain in `todo/`. Temporary article-level ideas should not become new governance files.
+
+## Per-Iteration Flow
+
+Each maintenance iteration follows this order:
+
+1. Review the current P0/P1 TODO goals and choose one main content target.
+2. Quickly check Issues and PRs, handling only items that are actionable, release-relevant, or reader-blocking.
+3. Complete the content, example code, indexes, and required English/Chinese sync for the iteration.
+4. Run the quality checks that match the change scope.
+5. If the change is reader-visible, update the changelog or prepare the next release entry.
+
+PRs and Issues should be checked at least once per iteration. Urgent problems may interrupt the cycle, such as broken site builds, important 404 pages, misleading example code, or external contributions that need quick feedback.
+
+## Version Cadence
+
+Version numbers describe the size of change; they should not force the writing schedule.
+
+- patch: typo fixes, links, site fixes, and low-risk text corrections.
+- minor: one volume or topic has clearly moved forward, giving readers a new learning path or complete capability.
+- major: TODO structure, site architecture, or the content system changes substantially.
+
+Patch releases can ship as needed. Minor releases usually use a 2 to 4 week observation window and ship only when a topic forms a complete increment. Major releases should stay rare to avoid repeatedly changing reader and contributor entry points.
+
+## Tags and Releases
+
+Tags and GitHub Releases are used separately. Tags mark lightweight maintenance checkpoints so readers can see ongoing progress through the README badge. GitHub Releases are reserved for content versions that readers should explicitly notice.
+
+- Patch-level fixes may be tagged without creating a GitHub Release.
+- Minor topic increments should usually create a Release with a changelog.
+- Major structural changes must create a Release and explain migration impact.
+
+This keeps project activity visible without overwhelming readers with Release notifications.
+
+## Definition of Done
+
+A content iteration should usually satisfy these conditions:
+
+- The article can be read independently, with terms and C++ standard versions clearly marked.
+- Related volume pages, chapter indexes, or navigation entries are updated.
+- Example code in the article can compile, or platform/toolchain limits are explicitly stated.
+- Key Chinese and English pages stay in sync; community drafts and low-priority long-form notes may be translated later.
+- Internal links pass checks, and the production build succeeds.
+
+For local fixes, run only the relevant checks. Before a release, run the full pre-release checks.
+
+## PR and Issue Handling
+
+Issues are for actionable problems, Discussions are for open-ended learning conversations, and PRs are for concrete changes.
+
+Handle items in this order:
+
+1. Problems that block builds, deployment, or major reading paths.
+2. Clear, low-risk fixes already submitted as PRs.
+3. Content suggestions directly related to the current iteration theme.
+4. Learning questions that can become QA entries, appendix material, or future TODO items.
+
+Learning questions should not fill the Issue list directly. High-quality discussions can be summarized into FAQ entries, appendix pages, or links from the main content.
+
+## Changelog Principles
+
+The changelog should describe reader-visible changes, not just file counts.
+
+Prefer recording:
+
+- Which learning path was added or completed.
+- Which examples can now run or be verified.
+- Which site entries, search behavior, navigation, or community flows improved.
+- Which contributors helped fix specific problems.
+
+File counts, line counts, and commit counts can be supporting data, but they should not replace the explanation of what changed.
+
+## Common Checks
+
+Choose checks by change scope during daily maintenance:
+
+```bash
+pnpm check:links
+python3 scripts/validate_frontmatter.py
+python3 scripts/check_quality.py documents/
+python3 scripts/build_examples.py --host
+```
+
+Before a release, run:
+
+```bash
+pnpm check:links
+pnpm build
+pnpm coverage:update
+python3 scripts/validate_frontmatter.py
+python3 scripts/check_quality.py documents/
+python3 scripts/build_examples.py --host
+```
+
+If STM32 examples changed, also run:
+
+```bash
+python3 scripts/build_examples.py --stm32
+```

--- a/documents/en/community/dev/index.md
+++ b/documents/en/community/dev/index.md
@@ -1,0 +1,25 @@
+---
+title: "Development"
+description: "Project maintenance cadence, development notes, release governance, and site evolution records under community collaboration"
+---
+
+# Development
+
+This section documents how Tutorial_AwesomeModernCPP itself is developed, maintained, and released. It lives under the community section because these practices support content collaboration, PR/Issue handling, and long-term site maintenance.
+
+It does not replace `todo/`, `changelogs/`, or `CONTRIBUTING.md`:
+
+- `todo/` tracks content roadmaps and volume-level plans.
+- `changelogs/` records changes that have already shipped.
+- `CONTRIBUTING.md` defines contribution, review, and quality rules.
+- `community/dev/` explains how maintainers move the site and content forward.
+
+## Development Notes
+
+<ChapterNav variant="main">
+  <ChapterLink num="1" href="01-iteration-cadence">Site Iteration Cadence</ChapterLink>
+</ChapterNav>
+
+## Principles
+
+The development section is for durable maintenance practices, not temporary task lists. Short-term work remains in the relevant volume TODO, and released changes remain in the changelog.

--- a/documents/en/community/index.md
+++ b/documents/en/community/index.md
@@ -1,0 +1,20 @@
+---
+title: "Community"
+description: "Community articles, reviewed submissions, and project development notes"
+---
+
+# Community
+
+This section collects community submissions and project maintenance notes for Tutorial_AwesomeModernCPP.
+
+Community content does not have to become part of the main tutorial volumes immediately. Contributors can submit Markdown first, maintainers can perform basic checks, and the content can later move into reviewed articles or a main tutorial chapter.
+
+## Sections
+
+<ChapterNav variant="main">
+  <ChapterLink num="1" href="dev/">Development</ChapterLink>
+</ChapterNav>
+
+## Development Notes
+
+Project maintenance cadence, site iteration, and release measurement are documented in [Development](dev/).


### PR DESCRIPTION
## 概述

本 PR 新增社区区下的“项目开发”文档，用于沉淀 Tutorial_AwesomeModernCPP 的网站迭代节奏、维护流程和版本度量方式。

主要变化：

- 新增 `documents/community/dev/` 项目开发区
- 新增英文镜像 `documents/en/community/dev/`
- 在社区首页增加“项目开发”入口
- 在 `CONTRIBUTING.md` 中增加开发节奏文档引用
- 在 README / README.en 中新增 tag badge
- 在开发手册中明确 tag 与 GitHub Release 的分工

## 设计说明

项目维护以内容产出为主，版本号用于度量内容推进幅度。patch 级变更可以只打 tag，让读者通过 README 徽章感知持续更新；GitHub Release 保留给 minor/major 等更值得读者关注的内容型版本，避免 Release 轰炸。