### PR TITLE
fix: add proof for the std::pmr::vector that it only use the stack space buffer instead of heap

### DIFF
--- a/documents/vol3-standard-library/13-custom-allocators.md
+++ b/documents/vol3-standard-library/13-custom-allocators.md
@@ -201,6 +201,8 @@ int main()
         v.push_back(i);
     }
     std::cout << "v.size() = " << v.size() << "\n";
+    std::cout << "v.data() address = " << std::hex << v.data() << "\n";
+    std::cout << "The range of stack buffer is [" << std::hex << (void *)buffer << "," << (void *)buffer+sizeof(buffer) << "]\n";
     std::cout << "vector 的内存来自栈上 buffer，零全局堆分配\n";
     return 0;
 }
@@ -212,6 +214,8 @@ g++ -std=c++20 -O2 -o /tmp/pmr_test /tmp/pmr_test.cpp && /tmp/pmr_test
 
 ```text
 v.size() = 100
+v.data() address = 0x7fff4f3c2fdc
+The range of stack buffer is [0x7fff4f3c2de0,0x7fff4f3c3de0]
 vector 的内存来自栈上 buffer，零全局堆分配
 ```
 


### PR DESCRIPTION
**Brief**: Augment the code sample in `std::pmr::vector` section.

The tutorial states `"vector 的内存来自栈上 buffer，零全局堆分配"` without actually prove it.

**QA**:

see godbolt reference: https://godbolt.org/z/WxjTb8oW5

@Charliechen114514 