### PR TITLE
feat: vol4 metaprogramming sub-volume complete (04-09 CN+EN)

### DIFF
--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/compile_time_hash.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/compile_time_hash.cpp
@@ -1,0 +1,31 @@
+// 配套 05-compile-time-strings.md「编译期哈希:不一定非得 NTTP」
+// FNV-1a 编译期字符串哈希(纯 constexpr 函数,不需要 NTTP)
+// 编译运行:g++ -std=c++20 -Wall -Wextra compile_time_hash.cpp -o cth && ./cth
+#include <cstdint>
+#include <iostream>
+#include <string_view>
+
+// FNV-1a 编译期字符串哈希(纯 constexpr 函数,不需要 NTTP)
+// 64 位魔法数是算法规定的
+constexpr std::uint64_t fnv1a_64(std::string_view s) {
+    std::uint64_t hash = 14695981039346656037ULL; // FNV offset basis
+    for (char c : s) {
+        hash ^= static_cast<std::uint64_t>(static_cast<unsigned char>(c));
+        hash *= 1099511628211ULL; // FNV prime
+    }
+    return hash;
+}
+
+int main() {
+    // 这些哈希值在编译期就算定
+    constexpr auto h_hello = fnv1a_64("hello");
+    constexpr auto h_hello2 = fnv1a_64("hello");
+    constexpr auto h_world = fnv1a_64("world");
+
+    static_assert(h_hello == h_hello2, "same string, same hash");
+    static_assert(h_hello != h_world, "different strings, different hash");
+
+    std::cout << "fnv1a_64(\"hello\") = " << h_hello << "\n";
+    std::cout << "fnv1a_64(\"world\") = " << h_world << "\n";
+    std::cout << "编译期哈希断言通过\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/enum_to_string.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/enum_to_string.cpp
@@ -1,0 +1,26 @@
+// 配套 06-static-reflection-basics.md「实战二:枚举转字符串」
+// ⚠️ 本机 GCC16/clang22 不支持 P2996(C++26 反射)。
+//    在 Godbolt 选 clang_bb_p2996(Bloomberg 实验分支)编译运行,参数 -std=c++2c -freflection-latest
+#include <iostream>
+#include <meta>
+#include <string_view>
+
+enum class Color { Red, Green, Blue };
+
+// 反射版:枚举值 -> 名字,不用手写任何 switch/查表
+template <typename E> constexpr std::string_view enum_to_string(E value) {
+    using namespace std::meta;
+    constexpr auto enumerators = define_static_array(enumerators_of(^^E));
+    template for (constexpr auto enumerator : enumerators) {
+        if (value == [:enumerator:]) {
+            return identifier_of(enumerator);
+        }
+    }
+    return "<unknown>";
+}
+
+int main() {
+    std::cout << enum_to_string(Color::Red) << "\n";
+    std::cout << enum_to_string(Color::Green) << "\n";
+    std::cout << enum_to_string(Color::Blue) << "\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/explicit_inst.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/explicit_inst.cpp
@@ -1,0 +1,5 @@
+#include "heavy_template.h"
+
+// 显式实例化定义:在这里实例化 Heavy<int> 的全部成员,
+// 供 use_b 等用了 extern template 声明的翻译单元链接
+template struct Heavy<int>;

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/heavy_template.h
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/heavy_template.h
@@ -1,0 +1,39 @@
+// 配套 07-template-instantiation-control.md「实测:机制怎么跑起来」
+// extern template + 显式实例化的多文件演示。本目录 5 个文件协作:
+//   heavy_template.h  模板定义(本文件)
+//   use_a.cpp         走老办法,隐式实例化 Heavy<int>
+//   use_b.cpp         用 extern template 抑制实例化
+//   explicit_inst.cpp 集中显式实例化 Heavy<int>
+//   main.cpp          串起来
+//
+// 编译运行:
+//   g++ -std=c++20 -Wall -Wextra -c use_a.cpp use_b.cpp explicit_inst.cpp main.cpp
+//   g++ use_a.o use_b.o explicit_inst.o main.o -o demo && ./demo
+//
+// 对照(去掉 explicit_inst.cpp,链接应失败,见正文「实测」节):
+//   g++ -std=c++20 -Wall -Wextra -c use_b.cpp main.cpp
+//   g++ use_b.o main.o -o demo_fail
+#pragma once
+
+// 一个适度「重」的模板:实例化会生成若干成员代码
+template <typename T> struct Heavy {
+    T value;
+
+    explicit Heavy(T v) : value(v) {}
+
+    T compute(T x) const {
+        T acc = value;
+        for (int i = 0; i < 10; ++i) {
+            acc = acc * x + value;
+        }
+        return acc;
+    }
+
+    T scale(T factor) const { return value * factor; }
+
+    T reset(T newv) {
+        T old = value;
+        value = newv;
+        return old;
+    }
+};

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/main.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/main.cpp
@@ -1,0 +1,7 @@
+void use_a();
+void use_b();
+
+int main() {
+    use_a();
+    use_b();
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/use_a.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/use_a.cpp
@@ -1,0 +1,8 @@
+#include "heavy_template.h"
+#include <iostream>
+
+// 这个翻译单元正常隐式实例化 Heavy<int>(用到时编译器自动生成)
+void use_a() {
+    Heavy<int> h{42};
+    std::cout << "use_a: " << h.compute(2) << "\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/use_b.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/extern_template/use_b.cpp
@@ -1,0 +1,10 @@
+#include "heavy_template.h"
+#include <iostream>
+
+// extern template 声明:Heavy<int> 别处已经显式实例化,这里别再生成代码
+extern template struct Heavy<int>;
+
+void use_b() {
+    Heavy<int> h{99};
+    std::cout << "use_b: " << h.compute(3) << "\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/fold_vs_recursion.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/fold_vs_recursion.cpp
@@ -1,0 +1,32 @@
+// 配套 04-tmp-core-techniques.md「fold expressions:干掉递归样板」
+// 对照 variadic 递归老办法和 C++17 fold expression 的新写法
+// 编译运行:g++ -std=c++20 -Wall -Wextra fold_vs_recursion.cpp -o fvr && ./fvr
+#include <iostream>
+
+// 老办法:variadic 模板递归 + 终止函数,算任意数量参数之和
+template <typename T> constexpr T sum_rec(T first) {
+    return first;
+}
+
+template <typename T, typename... Rest> constexpr T sum_rec(T first, Rest... rest) {
+    return first + sum_rec(rest...);
+}
+
+// C++17 fold expression:一行收掉上面那一坨
+template <typename... Ts> constexpr auto sum_fold(Ts... ts) {
+    return (ts + ...); // 一元右折叠
+}
+
+int main() {
+    std::cout << "sum_rec(1,2,3,4):  " << sum_rec(1, 2, 3, 4) << "\n";
+    std::cout << "sum_fold(1,2,3,4): " << sum_fold(1, 2, 3, 4) << "\n";
+
+    static_assert(sum_fold(1, 2, 3, 4) == 10);
+    static_assert(sum_fold(1, 2, 3, 4, 5, 6) == 21);
+
+    // fold 还能就地展开,把一堆值「打印」出来(逗号折叠)
+    std::cout << "逗号折叠展开: ";
+    auto printer = [](auto x) { std::cout << x << " "; };
+    (printer(1), printer(2.5), printer("hi"));
+    std::cout << "\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/mini_stl.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/mini_stl.cpp
@@ -1,0 +1,90 @@
+// 配套 09-mini-stl-with-concepts.md
+// 用 C++20 concepts 约束的 mini-STL 算法库:transform / accumulate / find_if
+//
+// 编译运行:
+//   g++ -std=c++20 -Wall -Wextra mini_stl.cpp -o mstl && ./mstl
+// 看传错类型的报错(NoPlus 不满足 Addable,concept 报错点名约束):
+//   g++ -std=c++20 -Wall -Wextra -DSHOW_ACC_ERROR mini_stl.cpp
+#include <concepts>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <ranges>
+#include <string>
+#include <vector>
+
+namespace my {
+
+// 自定义 concept:支持 a + b 且结果能转成 U
+template <typename T, typename U = T>
+concept Addable = requires(T a, U b) {
+    { a + b } -> std::convertible_to<U>;
+};
+
+// 自定义 concept:能用 < 比较
+template <typename T>
+concept Ordered = requires(T a, T b) {
+    { a < b } -> std::convertible_to<bool>;
+};
+
+// transform:把 range 经 func 变换后写到 out
+template <std::ranges::input_range R, typename Out, typename F>
+    requires std::output_iterator<Out, std::ranges::range_value_t<R>> &&
+             std::invocable<F&, std::ranges::range_reference_t<R>>
+Out transform(R&& r, Out out, F f) {
+    for (auto&& x : r) {
+        *out++ = std::invoke(f, x);
+    }
+    return out;
+}
+
+// accumulate:累加 range 的元素到 init
+template <std::ranges::input_range R, typename T>
+    requires Addable<T, std::ranges::range_value_t<R>>
+T accumulate(R&& r, T init) {
+    for (auto&& x : r) {
+        init = init + x;
+    }
+    return init;
+}
+
+// find_if:找第一个满足 pred 的元素
+template <std::ranges::input_range R, typename Pred>
+    requires std::predicate<Pred&, std::ranges::range_reference_t<R>>
+std::ranges::borrowed_iterator_t<R> find_if(R&& r, Pred pred) {
+    for (auto it = std::ranges::begin(r); it != std::ranges::end(r); ++it) {
+        if (std::invoke(pred, *it))
+            return it;
+    }
+    return std::ranges::end(r);
+}
+
+} // namespace my
+
+#ifdef SHOW_ACC_ERROR
+struct NoPlus {}; // 没有 operator+
+int main() {
+    std::vector<NoPlus> v(3);
+    my::accumulate(v, NoPlus{}); // Addable 约束不满足,concept 报错
+}
+#else
+int main() {
+    std::vector<int> v = {1, 2, 3, 4};
+
+    std::vector<int> squared;
+    my::transform(v, std::back_inserter(squared), [](int x) { return x * x; });
+    std::cout << "transform 平方: ";
+    for (int x : squared)
+        std::cout << x << " ";
+    std::cout << "\n";
+
+    std::cout << "accumulate 求和:  " << my::accumulate(v, 0) << "\n";
+
+    std::vector<std::string> words = {"a", "b", "c"};
+    std::cout << "accumulate 拼接:  " << my::accumulate(words, std::string("start:")) << "\n";
+
+    auto it = my::find_if(v, [](int x) { return x % 2 == 0; });
+    if (it != v.end())
+        std::cout << "find_if 第一个偶数: " << *it << "\n";
+}
+#endif

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/move_if_noexcept_demo.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/move_if_noexcept_demo.cpp
@@ -1,0 +1,49 @@
+// 配套 08-templates-and-exception-safety.md「move_if_noexcept:可能要回滚时,退回拷贝」
+// 演示 move_if_noexcept 怎么按 move 是否 noexcept 在 move/copy 之间挑
+// 编译运行:g++ -std=c++20 -Wall -Wextra move_if_noexcept_demo.cpp -o mind && ./mind
+#include <iostream>
+#include <type_traits>
+#include <utility>
+
+// 移动构造 noexcept:move_if_noexcept 会选 move
+struct NothrowMove {
+    int* p;
+    explicit NothrowMove(int v) : p(new int(v)) {}
+    ~NothrowMove() { delete p; }
+    NothrowMove(const NothrowMove& o) : p(new int(*o.p)) {
+        std::cout << "    [NothrowMove] 被拷贝\n";
+    }
+    NothrowMove(NothrowMove&& o) noexcept : p(o.p) {
+        o.p = nullptr;
+        std::cout << "    [NothrowMove] 被移动\n";
+    }
+};
+
+// 移动构造可能抛:move_if_noexcept 会退回选 copy
+struct ThrowingMove {
+    int* p;
+    explicit ThrowingMove(int v) : p(new int(v)) {}
+    ~ThrowingMove() { delete p; }
+    ThrowingMove(const ThrowingMove& o) : p(new int(*o.p)) {
+        std::cout << "    [ThrowingMove] 被拷贝\n";
+    }
+    ThrowingMove(ThrowingMove&& o) noexcept(false) : p(o.p) { // 故意 noexcept(false)
+        o.p = nullptr;
+        std::cout << "    [ThrowingMove] 被移动\n";
+    }
+};
+
+int main() {
+    std::cout << std::boolalpha;
+    std::cout << "is_nothrow_move_constructible:\n";
+    std::cout << "  NothrowMove:  " << std::is_nothrow_move_constructible_v<NothrowMove> << "\n";
+    std::cout << "  ThrowingMove: " << std::is_nothrow_move_constructible_v<ThrowingMove> << "\n";
+
+    std::cout << "move_if_noexcept 对 NothrowMove(应为 move):\n";
+    NothrowMove nm(1);
+    [[maybe_unused]] auto nm2 = std::move_if_noexcept(nm);
+
+    std::cout << "move_if_noexcept 对 ThrowingMove(应为 copy):\n";
+    ThrowingMove tm(2);
+    [[maybe_unused]] auto tm2 = std::move_if_noexcept(tm);
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/noexcept_propagation.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/noexcept_propagation.cpp
@@ -1,0 +1,41 @@
+// 配套 08-templates-and-exception-safety.md「条件 noexcept:把底层会不会抛如实传出去」
+// 对比「没标 noexcept」和「条件 noexcept」在调用方眼里的 noexcept 性
+// 编译运行:g++ -std=c++20 -Wall -Wextra noexcept_propagation.cpp -o nep && ./nep
+#include <iostream>
+#include <utility>
+
+struct NoThrowMove {
+    NoThrowMove() = default;
+    NoThrowMove(NoThrowMove&&) noexcept {} // 显式 noexcept
+    NoThrowMove(const NoThrowMove&) = default;
+    NoThrowMove& operator=(NoThrowMove&&) noexcept { return *this; }
+};
+
+struct ThrowMove {
+    ThrowMove() = default;
+    ThrowMove(ThrowMove&&) {} // 没标,隐式可能抛
+    ThrowMove(const ThrowMove&) = default;
+    ThrowMove& operator=(ThrowMove&&) { return *this; }
+};
+
+// 没标 noexcept:调用方只能保守地认为它可能抛
+template <typename T> void uncond_op(T& x) {
+    T tmp(std::move(x));
+    x = std::move(tmp);
+}
+
+// 条件 noexcept:继承「T 的移动构造是否 noexcept」
+template <typename T> void cond_op(T& x) noexcept(noexcept(T(std::move(x)))) {
+    T tmp(std::move(x));
+    x = std::move(tmp);
+}
+
+int main() {
+    std::cout << std::boolalpha;
+    std::cout << "uncond_op<NoThrowMove> noexcept: "
+              << noexcept(uncond_op(std::declval<NoThrowMove&>())) << "\n";
+    std::cout << "cond_op<NoThrowMove> noexcept:   "
+              << noexcept(cond_op(std::declval<NoThrowMove&>())) << "\n";
+    std::cout << "cond_op<ThrowMove> noexcept:     "
+              << noexcept(cond_op(std::declval<ThrowMove&>())) << "\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/nttp_cstr_pitfall.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/nttp_cstr_pitfall.cpp
@@ -1,0 +1,30 @@
+// 配套 05-compile-time-strings.md「先说麻烦:C++17 之前 const char* 作 NTTP 的难处」
+// 演示字符串字面量为什么不能直接作 NTTP(无 linkage)
+//
+// 默认编译跑:有 linkage 的 constexpr 变量能作 NTTP
+//   g++ -std=c++20 -Wall -Wextra nttp_cstr_pitfall.cpp -o cstr && ./cstr
+// 看字面量直接作 NTTP 的报错:
+//   g++ -std=c++20 -Wall -Wextra -DSHOW_LITERAL_ERROR nttp_cstr_pitfall.cpp
+#include <iostream>
+
+// 有外部链接的 constexpr 字符串变量,能作 NTTP
+constexpr const char kRed[] = "red";
+
+template <const char* Name> struct Tagged {
+    static constexpr const char* name = Name;
+};
+
+#ifdef SHOW_LITERAL_ERROR
+template <const char* Name> struct Bad {};
+Bad<"hello"> b; // 字符串字面量无 linkage,不能作 NTTP
+#else
+int main() {
+    std::cout << "kRed 的内容 = " << kRed << "\n";
+
+    // OK:kRed 是有 linkage 的对象,能作模板参数(数组到指针衰减)
+    Tagged<kRed> t;
+    std::cout << "Tagged<kRed>::name = " << t.name << "\n";
+    std::cout
+        << "\n字符串字面量 \"hello\" 不能直接写进 template<...>,加 -DSHOW_LITERAL_ERROR 看报错\n";
+}
+#endif

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/nttp_fixed_string.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/nttp_fixed_string.cpp
@@ -1,0 +1,49 @@
+// 配套 05-compile-time-strings.md「C++20 的解药:P0732 与 structural type」
+// fixed_string 惯用法:把字符串包进 structural 结构体,当非类型模板参数(NTTP)用
+// 编译运行:g++ -std=c++20 -Wall -Wextra nttp_fixed_string.cpp -o nfs && ./nfs
+#include <iostream>
+
+// C++20:NTTP 可以是 class type,只要它是 structural(所有基类和数据成员 public)
+// fixed_string:把字符串包进结构体,从而能当模板参数
+template <std::size_t N> struct FixedString {
+    char value[N] = {};
+
+    // 用 const char 数组构造(字面量 "abc" 是 const char[4],含 \0)
+    constexpr FixedString(const char (&str)[N]) {
+        for (std::size_t i = 0; i < N; ++i) {
+            value[i] = str[i];
+        }
+    }
+
+    constexpr bool operator==(const FixedString& other) const {
+        for (std::size_t i = 0; i < N; ++i) {
+            if (value[i] != other.value[i])
+                return false;
+        }
+        return true;
+    }
+
+    constexpr const char* c_str() const { return value; }
+};
+
+// CTAD 推导指引:让字面量 "hello" 推导出 FixedString<6>(含 \0)
+template <std::size_t N> FixedString(const char (&)[N]) -> FixedString<N>;
+
+// 把 FixedString 当 NTTP 用
+template <FixedString S> struct Named {
+    static constexpr auto name = S;
+};
+
+template <FixedString S> void greet() {
+    std::cout << "hello, " << S.c_str() << "\n";
+}
+
+int main() {
+    std::cout << Named<"world">{}.name.c_str() << "\n";
+    greet<"templates">();
+
+    // 编译期字符串比较
+    static_assert(FixedString{"abc"} == FixedString{"abc"});
+    static_assert(!(FixedString{"abc"} == FixedString{"abd"}));
+    std::cout << "编译期字符串比较断言通过\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/sfinae_vs_concept.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/sfinae_vs_concept.cpp
@@ -1,0 +1,39 @@
+// 配套 04-tmp-core-techniques.md「SFINAE 往 concepts 迁移」
+// 同一需求(只接受整数)的两种写法:enable_if 老办法 vs concept 新办法
+//
+// 默认编译跑:两种写法对 int 都正常
+//   g++ -std=c++20 -Wall -Wextra sfinae_vs_concept.cpp -o svc && ./svc
+//
+// 看 SFINAE 版报错(用 string 触发,对照正文里 enable_if 的天书):
+//   g++ -std=c++20 -Wall -Wextra -DSHOW_SFINAE_ERROR sfinae_vs_concept.cpp
+//
+// 看 concept 版报错(对照正文里 constraints not satisfied 的人话):
+//   g++ -std=c++20 -Wall -Wextra -DSHOW_CONCEPT_ERROR sfinae_vs_concept.cpp
+#include <concepts>
+#include <iostream>
+#include <string>
+#include <type_traits>
+
+// SFINAE 老办法:约束藏在默认模板参数里
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>> T add_old(T a, T b) {
+    return a + b;
+}
+
+// concept 新办法:约束写在签名里
+template <typename T>
+    requires std::integral<T>
+T add_new(T a, T b) {
+    return a + b;
+}
+
+int main() {
+#ifdef SHOW_SFINAE_ERROR
+    add_old(std::string("a"), std::string("b"));
+#elif defined(SHOW_CONCEPT_ERROR)
+    add_new(std::string("a"), std::string("b"));
+#else
+    std::cout << "add_old(2, 3) = " << add_old(2, 3) << "\n";
+    std::cout << "add_new(2, 3) = " << add_new(2, 3) << "\n";
+    std::cout << "两种写法对 int 都正常;想看报错加 -DSHOW_SFINAE_ERROR 或 -DSHOW_CONCEPT_ERROR\n";
+#endif
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/struct_members.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/struct_members.cpp
@@ -1,0 +1,23 @@
+// 配套 06-static-reflection-basics.md「实战一:遍历 struct 的成员」
+// ⚠️ 本机 GCC16/clang22 不支持 P2996(C++26 反射)。
+//    在 Godbolt 选 clang_bb_p2996(Bloomberg 实验分支)编译运行,参数 -std=c++2c -freflection-latest
+#include <iostream>
+#include <meta>
+
+struct Point {
+    int x;
+    int y;
+};
+
+int main() {
+    using namespace std::meta;
+    constexpr auto refl = ^^Point;
+    constexpr auto ctx = access_context::current();
+    // define_static_array 把 vector 物化到静态存储,template for 才能编过
+    constexpr auto members = define_static_array(nonstatic_data_members_of(refl, ctx));
+
+    std::cout << identifier_of(refl) << "\n";
+    template for (constexpr auto member : members) {
+        std::cout << "  " << identifier_of(member) << "\n";
+    }
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/structural_limit.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/structural_limit.cpp
@@ -1,0 +1,37 @@
+// 配套 05-compile-time-strings.md「structural 的限制」
+// NTTP class type 要求类型是 structural:所有基类和非静态数据成员必须 public
+//
+// 默认编译跑:Open(public 数据成员)能作 NTTP
+//   g++ -std=c++20 -Wall -Wextra structural_limit.cpp -o sl && ./sl
+// 看 Secret 不能作 NTTP 的报错:加 -DSHOW_NON_STRUCTURAL
+//   g++ -std=c++20 -Wall -Wextra -DSHOW_NON_STRUCTURAL structural_limit.cpp
+#include <iostream>
+
+// ✅ structural:public 数据成员
+struct Open {
+    int x;
+    int y;
+};
+
+template <Open O> struct Wrapper {
+    static constexpr int sum = O.x + O.y;
+};
+
+#ifdef SHOW_NON_STRUCTURAL
+// ❌ 非 structural:默认 class 的成员是 private
+class Secret {
+    int x; // private
+  public:
+    constexpr Secret(int v) : x(v) {}
+};
+
+template <Secret S> struct Bad {}; // 报错:Secret 不是 structural type
+Bad<Secret{1}> bad;
+#else
+int main() {
+    static_assert(Wrapper<Open{3, 4}>{}.sum == 7);
+    static_assert(Wrapper<Open{10, 20}>{}.sum == 30);
+    std::cout << "Open{3,4} 的 sum = " << Wrapper<Open{3, 4}>{}.sum << "\n";
+    std::cout << "public 成员的 struct 能作 NTTP;private 成员的不行,加 -DSHOW_NON_STRUCTURAL 看\n";
+}
+#endif

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/tmp_factorial.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/tmp_factorial.cpp
@@ -1,0 +1,21 @@
+// 配套 04-tmp-core-techniques.md「模板递归:用实例化做循环」
+// 演示经典 TMP 范式:模板递归 + 特化终止,在编译期算阶乘
+// 编译运行:g++ -std=c++20 -Wall -Wextra tmp_factorial.cpp -o tf && ./tf
+#include <iostream>
+
+// 经典 TMP:模板递归计算阶乘,靠特化提供终止条件
+template <unsigned N> struct Factorial {
+    static constexpr unsigned value = N * Factorial<N - 1>::value;
+};
+
+template <> struct Factorial<0> {
+    static constexpr unsigned value = 1;
+};
+
+int main() {
+    std::cout << "Factorial<5>::value  = " << Factorial<5>::value << "\n";
+    std::cout << "Factorial<10>::value = " << Factorial<10>::value << "\n";
+    static_assert(Factorial<5>::value == 120, "5! should be 120");
+    static_assert(Factorial<10>::value == 3628800, "10! should be 3628800");
+    std::cout << "编译期断言全部通过\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/traits_from_scratch.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/traits_from_scratch.cpp
@@ -1,0 +1,29 @@
+// 配套 04-tmp-core-techniques.md「type_traits 的内幕:特化就是编译期的 if-else」
+// 手写一个 is_pointer,看清 type_traits 「主模板 + 偏特化」的实现机制
+// 编译运行:g++ -std=c++20 -Wall -Wextra traits_from_scratch.cpp -o tfs && ./tfs
+#include <iostream>
+#include <type_traits>
+
+// 手写一个 is_pointer:主模板兜底 false
+template <typename T> struct is_pointer_impl {
+    static constexpr bool value = false;
+};
+
+// 偏特化:匹配「指向 T 的指针」,true
+template <typename T> struct is_pointer_impl<T*> {
+    static constexpr bool value = true;
+};
+
+template <typename T> constexpr bool is_pointer_v = is_pointer_impl<T>::value;
+
+int main() {
+    std::cout << std::boolalpha;
+    std::cout << "is_pointer_v<int>:    " << is_pointer_v<int> << "\n";
+    std::cout << "is_pointer_v<int*>:   " << is_pointer_v<int*> << "\n";
+    std::cout << "is_pointer_v<int**>:  " << is_pointer_v<int**> << "\n";
+    std::cout << "is_pointer_v<double*>:" << is_pointer_v<double*> << "\n";
+    // 和标准库对照,结果应一致
+    static_assert(is_pointer_v<int*> == std::is_pointer_v<int*>);
+    static_assert(is_pointer_v<int> == std::is_pointer_v<int>);
+    std::cout << "与 std::is_pointer 结果一致\n";
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/vector_realloc.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/vector_realloc.cpp
@@ -1,0 +1,42 @@
+// 配套 08-templates-and-exception-safety.md「vector 扩容凭什么保住强异常保证」
+// vector 扩容时,move noexcept 的元素被 move,move 可能抛的元素被 copy(保强保证)
+// 编译运行:g++ -std=c++20 -Wall -Wextra vector_realloc.cpp -o vr && ./vr
+#include <iostream>
+#include <vector>
+
+// 故意写得能追踪 copy/move 次数
+struct NothrowMove {
+    int v;
+    explicit NothrowMove(int x) : v(x) {}
+    NothrowMove(const NothrowMove& o) : v(o.v) { std::cout << "    copy\n"; }
+    NothrowMove(NothrowMove&& o) noexcept : v(o.v) { std::cout << "    move\n"; }
+};
+
+struct ThrowingMove {
+    int v;
+    explicit ThrowingMove(int x) : v(x) {}
+    ThrowingMove(const ThrowingMove& o) : v(o.v) { std::cout << "    copy\n"; }
+    ThrowingMove(ThrowingMove&& o) noexcept(false) : v(o.v) { std::cout << "    move\n"; }
+};
+
+int main() {
+    std::cout << "vector<NothrowMove> 预留 2,再 push 第三个触发扩容:\n";
+    {
+        std::vector<NothrowMove> v;
+        v.reserve(2);
+        v.emplace_back(1);
+        v.emplace_back(2);
+        std::cout << "  >>> 扩容时(move noexcept,应为 move):\n";
+        v.emplace_back(3);
+    }
+
+    std::cout << "\nvector<ThrowingMove> 预留 2,再 push 第三个触发扩容:\n";
+    {
+        std::vector<ThrowingMove> v;
+        v.reserve(2);
+        v.emplace_back(1);
+        v.emplace_back(2);
+        std::cout << "  >>> 扩容时(move 可能抛,应为 copy 保强异常保证):\n";
+        v.emplace_back(3);
+    }
+}

--- a/code/examples/vol4/vol3-metaprogramming-cpp20-23/void_t_detection.cpp
+++ b/code/examples/vol4/vol3-metaprogramming-cpp20-23/void_t_detection.cpp
@@ -1,0 +1,25 @@
+// 配套 04-tmp-core-techniques.md「void_t 与 detection idiom」
+// 用 void_t 的 detection idiom 检测类型是否有 value_type 内嵌类型
+// 编译运行:g++ -std=c++20 -Wall -Wextra void_t_detection.cpp -o vtd && ./vtd
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+// detection idiom:用 void_t 检测 T 是否有 value_type 内嵌类型
+// 主模板:默认继承 false_type(给个 void 占位,匹配不上特化时落到这里)
+template <typename T, typename = void> struct has_value_type : std::false_type {};
+
+// 偏特化:只有当 void_t<...> 里的替换成功时,这个特化才「更特化」从而被选中
+template <typename T> struct has_value_type<T, std::void_t<typename T::value_type>>
+    : std::true_type {};
+
+template <typename T> constexpr bool has_value_type_v = has_value_type<T>::value;
+
+int main() {
+    std::cout << std::boolalpha;
+    std::cout << "has_value_type_v<std::vector<int>>: "
+              << has_value_type_v<std::vector<int>> << "\n";
+    std::cout << "has_value_type_v<std::string>:      " << has_value_type_v<std::string> << "\n";
+    std::cout << "has_value_type_v<int>:              " << has_value_type_v<int> << "\n";
+}

--- a/documents/en/vol2-modern-features/ch00-move-semantics/05-move-in-practice.md
+++ b/documents/en/vol2-modern-features/ch00-move-semantics/05-move-in-practice.md
@@ -724,13 +724,13 @@ After copy construction, `arr2` owns an independent copy of the data; modifying 
 
 Run the two examples and verify the key claims of this article yourself:
 
-<OnlineCompilerDemo
+<OnlineCompilerDemo allow-run
   title="push_back vs emplace_back: copy, move, in-place construction"
   source-path="code/examples/vol2/push_back_emplace.cpp"
   description="Trace the construction, copy, move, and destruction logs of Heavy objects to compare push_back(lvalue), push_back(rvalue), and emplace_back."
 />
 
-<OnlineCompilerDemo
+<OnlineCompilerDemo allow-run
   title="How noexcept affects sort vs vector reallocation"
   source-path="code/examples/vol2/noexcept_sort_vs_realloc.cpp"
   description="Count copies and moves: std::sort doesn't distinguish noexcept, but vector reallocation falls back to copy for non-noexcept move types via move_if_noexcept."

--- a/documents/en/vol4-advanced/vol1-basics-cpp11-14/index.md
+++ b/documents/en/vol4-advanced/vol1-basics-cpp11-14/index.md
@@ -7,8 +7,6 @@ description: "The core foundation of C++ template programming: a complete introd
 
 C++ templates are the core mechanism of generic programming. This part moves from "using templates" to "writing libraries, reading STL source," covering the compilation model, specialization and partial specialization, non-type parameters, two-phase name lookup, hidden friends, alias templates, and CRTP, finally welding the first nine pieces together with a `fixed_vector<T, N>` project.
 
-Every piece ships with "run it and see" real compile output, traps written up as `::: warning` blocks, and key compile-time behavior backed by assembly.
-
 Runnable examples live in [code/examples/vol4/vol1-basics-cpp11-14/](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/examples/vol4/vol1-basics-cpp11-14): the four most reusable ones (fixed_vector, CRTP static polymorphism, the Comparable mixin, and type_traits from scratch), each compiles with `g++ -std=c++20 xxx.cpp`.
 
 <ChapterNav variant="sub">

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/01-concepts.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/01-concepts.md
@@ -1,0 +1,223 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 'A concept is a named compile-time predicate. It lifts the requirement on a template parameter out of the enable_if dark arts and puts it in the signature. The four syntax forms, the error message contrast with enable_if, and the standard library concepts you reach for most.'
+difficulty: intermediate
+order: 1
+platform: host
+prerequisites:
+- 'Class templates: members, dependent names, lazy instantiation'
+- 'Alias templates and the using declaration'
+reading_time_minutes: 13
+related:
+- 'Constraining templates with concepts: subsumption and overloading'
+- 'Requires expressions, in depth: the four kinds'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 泛型
+- concepts
+- 类型安全
+title: 'Concepts: Putting Constraints in the Signature'
+---
+# Concepts: Putting Constraints in the Signature
+
+Back in Volume 1 we wrote function templates. We know that `template <typename T> T add(T a, T b)` works for `int`, for `double`, and so on. But the moment you want to say "`add` only takes numeric types, strings stay out," the pre-C++20 answer was `std::enable_if`. You shoved the constraint into an extra default template parameter and let SFINAE kick this overload out when substitution failed. It works. But it buries a simple requirement inside layers of template-parameter nesting, and the error messages are worse. When something goes wrong, the compiler dumps a wall of `enable_if<false, void>` internal expansion, and you have to already understand SFINAE to guess which condition wasn't met.
+
+C++20 concepts fix exactly this. They let you **name the constraint and put it in the signature**, writing requirements the way you write types, and the compiler can finally report "constraint not satisfied" in words a person can read. This piece covers what a concept actually is, the forms it comes in, why its error messages save you half your hair, and the ready-made concepts in `<concepts>` you can use today.
+
+## What a concept is: a named compile-time predicate
+
+A concept is at bottom a **predicate that evaluates to bool at compile time**, except you gave it a name. The name is the point. With a name, it can show up in a signature, get named in an error, and be reused across templates.
+
+```cpp
+#include <concepts>
+
+// Define a concept: T is "numeric" if it's an integer or floating-point type
+template <typename T>
+concept Numeric = std::integral<T> || std::floating_point<T>;
+```
+
+`Numeric<T>` evaluates to `true` or `false` at compile time. It produces no code on its own. It is just a named judgment. Once you have the name, you can use it directly as a constraint in the template parameter list:
+
+```cpp
+template <Numeric T>
+T add(T a, T b) {
+    return a + b;
+}
+```
+
+Read `template <Numeric T>` as "`T` is a `Numeric` type." The constraint went from "dark magic hidden in a default template parameter" to "a plain requirement written where the type goes." That is the core value of a concept: it gives the constraint a name, making the requirement readable, reusable, and referenceable by the compiler.
+
+## Four syntax forms
+
+Once a concept exists, there are four places it can show up in a template. Let's write the same `add` four ways. All of them compile and run.
+
+```cpp
+#include <concepts>
+#include <iostream>
+#include <string>
+
+template <typename T>
+concept Numeric = std::integral<T> || std::floating_point<T>;
+
+// Form 1: the concept directly as a constraint in the template parameter list
+template <Numeric T>
+T form1(T a, T b) { return a + b; }
+
+// Form 2: a requires clause (trailing requires-clause), after the parameter list
+template <typename T>
+    requires Numeric<T>
+T form2(T a, T b) { return a + b; }
+
+// Form 3: abbreviated template syntax (constrained auto), a constraint before auto
+auto form3(Numeric auto a, Numeric auto b) { return a + b; }
+
+// Form 4: a requires after the parameter list, with a requires expression inside
+template <typename T>
+    requires requires(T x) { x + x; }
+T form4(T a, T b) { return a + b; }
+```
+
+Form 1 is the most direct. It fits the case where the constraint is already a concept you have. Form 2, the requires clause, is more flexible, and we'll see it combine multiple conditions later. Form 3 is C++20 shorthand that reads like an ordinary function. `Numeric auto` is equivalent to a constrained template parameter. Form 4 has two `requires` in a row. The outer one is a clause, the inner one is an expression (we take that apart in the next piece). This form doesn't need a concept defined up front; you describe the requirement on the spot.
+
+Run it, calling each form once:
+
+<OnlineCompilerDemo allow-run
+  title="The four syntax forms of a concept"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/concepts_four_forms.cpp"
+  description="Constrain the same add four ways: in the parameter list, as a requires clause, as constrained auto, and as an inline requires expression."
+/>
+
+Run it:
+
+```text
+form1: 8
+form2: 5
+form3: 30
+form4: ab
+```
+
+Four writes, four calls, all returning what you'd expect. Form 4 takes `std::string` fine too, because `string` has `operator+`, and the inner `requires(T x) { x + x; }` holds for it.
+
+## The error message contrast: why concepts save your hair
+
+Saying "the errors are better" is empty. Let's run it. Same `add`, constrained to "numeric only" once with `enable_if` and once with a concept. Then we deliberately call it with `std::string` and see what each version prints.
+
+First, the `enable_if` version (excerpt):
+
+```text
+add_enable_if.cpp:13:8: error: no matching function for call to 'add(std::string&, std::string&)'
+   13 |     add(s1, s2);
+      |     ~~~^~~~~~~~
+  • candidate 1: 'template<class T, class> T add(T, T)'
+      • template argument deduction/substitution failed:
+        • /usr/include/c++/16/type_traits: In substitution of
+          'template<bool _Cond, class _Tp> using std::enable_if_t = ... [with bool _Cond = false; _Tp = void]':
+        • error: no type named 'type' in 'struct std::enable_if<false, void>'
+```
+
+The heart of the error is that last line, `no type named 'type' in 'struct std::enable_if<false, void>'`. You have to know that `enable_if<false>` has no `type` member, and know this is SFINAE kicking the overload out on substitution failure, to back out "oh, it's because `string` isn't numeric." The whole message is about `enable_if`'s internals. It says nothing about the thing you actually care about: what did `string` fail to satisfy.
+
+Now the concept version (excerpt):
+
+```text
+add_concept.cpp:16:8: error: no matching function for call to 'add(std::string&, std::string&)'
+  • candidate 1: 'template<class T>  requires  Numeric<T> T add(T, T)'
+      • template argument deduction/substitution failed:
+        • constraints not satisfied
+          • required for the satisfaction of 'Numeric<T>'
+              [with T = std::__cxx11::basic_string<char>]
+            concept Numeric = std::integral<T> || std::floating_point<T>;
+```
+
+The key difference is `constraints not satisfied` and `required for the satisfaction of 'Numeric<T>' [with T = ... basic_string<char>]`. The compiler tells you straight: `string` did not satisfy `Numeric`. The constraint's name is called out, and the failing type is substituted in. You don't need to understand SFINAE, you don't read any `enable_if` expansion. You see at a glance which rule didn't pass.
+
+::: warning Don't judge by line count alone
+On a newer GCC (we're using 16.1.1 here), the two errors are actually close in length. The compiler has learned to structure the `enable_if` diagnostics too. So the win from concepts is not "the error is dozens of lines shorter," that's old talk. The win is that **the information points straight at the constraint**. What you want is "string is not Numeric," not "enable_if<false> has no type." On an older compiler (GCC 9 or 10, say), the length gap is brutal, and that was one of the main forces behind concepts back then.
+:::
+
+Readability of errors is the most direct payoff of concepts. When you write a library and someone passes the wrong type, they no longer see hieroglyphics. They see "the Numeric constraint wasn't satisfied."
+
+## The ready-made concepts in `<concepts>`
+
+You don't have to write every concept yourself. The standard library `<concepts>` ships a batch of common ones, covering type relations, constructibility, convertibility, and other high-frequency cases. Let's pick a few you bump into most and actually run them:
+
+```cpp
+#include <concepts>
+#include <iostream>
+#include <vector>
+
+struct Base {};
+struct Derived : Base {};
+struct Unrelated {};
+
+int main() {
+    std::cout << std::boolalpha;
+    std::cout << "same_as<int,int>:             " << std::same_as<int, int> << "\n";
+    std::cout << "same_as<int, const int>:      " << std::same_as<int, const int> << "\n";
+    std::cout << "convertible_to<int,double>:   " << std::convertible_to<int, double> << "\n";
+    std::cout << "convertible_to<double,int>:   " << std::convertible_to<double, int> << "\n";
+    std::cout << "derived_from<Derived,Base>:   " << std::derived_from<Derived, Base> << "\n";
+    std::cout << "derived_from<Unrelated,Base>: " << std::derived_from<Unrelated, Base> << "\n";
+    std::cout << "common_with<int,double>:      " << std::common_with<int, double> << "\n";
+    std::cout << "default_initializable<int>:   " << std::default_initializable<int> << "\n";
+    std::cout << "integral<int>:                " << std::integral<int> << "\n";
+    std::cout << "integral<bool>:               " << std::integral<bool> << "\n";
+    std::cout << "floating_point<float>:        " << std::floating_point<float> << "\n";
+}
+```
+
+<OnlineCompilerDemo allow-run
+  title="Standard library concepts, run live"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/stdconcepts_demo.cpp"
+  description="Real judgments from same_as, convertible_to, derived_from, common_with, integral, and floating_point."
+/>
+
+Run it:
+
+```text
+same_as<int,int>:             true
+same_as<int, const int>:      false
+convertible_to<int,double>:   true
+convertible_to<double,int>:   true
+derived_from<Derived,Base>:   true
+derived_from<Unrelated,Base>: false
+common_with<int,double>:      true
+default_initializable<int>:   true
+integral<int>:                true
+integral<bool>:               true
+floating_point<float>:        true
+```
+
+There's a trap here that's easy to step on. `same_as<int, const int>` comes out **false**, even though your gut says "they're both int." The reason is that the `const` qualifier makes them two distinct types. `std::is_same_v<int, const int>` is false to begin with, and `same_as` is built on top of it, so it's false too. If you want "after stripping cv-qualifiers and references, is it the same type," you have to erase the qualifiers with `std::remove_cvref_t` first, then compare.
+
+`derived_from` also checks accessibility of the inheritance (only `public` inheritance counts). A privately inherited base will return false here. `convertible_to` allows implicit narrowing, so `int` to `double` (promotion) and `double` to `int` (narrowing) are both true. The standard library has no ready-made "no narrowing" concept. When you need strict numeric checking, you either accept this loose behavior or pair `std::is_convertible_v` with a no-narrowing trait of your own to block it. `integral<bool>` is true because `bool` belongs to the integer type family in the standard. When you write numeric algorithms and want to decide whether `bool` counts, that's on you to filter with `std::integral && !std::same_as<T, bool>`.
+
+These off-the-shelf concepts cover about nine tenths of everyday type judgments. The cases where you actually need to write your own concept are usually "this algorithm requires the type to provide certain operations." Things like "has a `size()` method," "can be compared with `<`," "has a `value_type` nested type." We'll come back to those repeatedly when we talk about constraining templates and requires expressions.
+
+## A concept is a bool, you can use it directly to judge
+
+A concept is, in the end, a compile-time bool. So it doesn't only live in signatures. It can be used directly anywhere you need a compile-time judgment, like `static_assert` or `if constexpr`:
+
+```cpp
+template <typename T>
+concept Numeric = std::integral<T> || std::floating_point<T>;
+
+static_assert(Numeric<int>);          // compile-time assertion: int is numeric
+static_assert(!Numeric<std::string>); // string isn't, assert that it "isn't"
+
+template <typename T>
+void describe(T x) {
+    if constexpr (Numeric<T>) {
+        // compile-time branch: this block only compiles when T is numeric
+    }
+}
+```
+
+This becomes the main character in the next piece, how to use a concept to constrain templates and do overload dispatch. With a constraint that doubles as a bool, overload resolution based on constraints finally has something to stand on.
+
+In the next piece we go a level deeper. A concept isn't just "nice to look at in a signature." It actually participates in **overload resolution**. When several overloads with different constraints sit together, the compiler picks the best fit using a rule called subsumption (constraint entailment). That is the part of concepts that actually changes how you write generic code.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/02-constraining-templates.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/02-constraining-templates.md
@@ -1,0 +1,234 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 'Writing a concept into the signature is only the first step. What actually changes how you write generic code is that concepts take part in overload resolution. How subsumption (constraint entailment) picks the best fit among constrained overloads, and the trap hidden in atomic constraints.'
+difficulty: intermediate
+order: 2
+platform: host
+prerequisites:
+- 'Concepts: Putting Constraints in the Signature'
+reading_time_minutes: 14
+related:
+- 'Concepts: Putting Constraints in the Signature'
+- 'Requires expressions, in depth: the four kinds'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 泛型
+- concepts
+- 类型安全
+title: 'Constraining Templates with Concepts: Subsumption and Overloading'
+---
+# Constraining Templates with Concepts: Subsumption and Overloading
+
+In the last piece we put a concept into the signature and watched the error go from `enable_if` internal expansion to a plain "constraint not satisfied." But the thing that actually changes how you write generic code is something else. Concepts make template **overloading** workable. In C++17 and earlier, two function templates would clash unless their parameter counts or types were clearly different, and conditional overloading through `enable_if` was painful to write. With concepts, you can write a pile of same-named overloads with distinct constraints and let the compiler pick based on which constraint the argument satisfies. The rule for picking is called **subsumption** (constraint entailment), and it is the main character of this piece.
+
+## First, untangle two same-named things: the requires clause and the requires expression
+
+Before going further, we have to separate the two uses of the word `requires`, or everything below turns into a blur.
+
+A **requires clause** (requires-clause) shows up after the template parameter list. Its job is "add a constraint to the template." We saw it as Form 2 in the last piece:
+
+```cpp
+template <typename T>
+    requires Numeric<T>      // this whole line is a requires clause
+T add(T a, T b) { return a + b; }
+```
+
+A **requires expression** (requires-expression) is an expression that evaluates to `bool` at compile time. It describes on the spot "what operations the type must provide." The next piece takes it apart. For now, a glance:
+
+```cpp
+requires(T t) { t + t; t.size(); }   // this is a requires expression, value is bool
+```
+
+The difference is that the clause is a syntactic position where you "set a rule" for the template, while the expression is the formula that describes the rule and produces a truth value. A clause often contains an expression, like `requires requires(T t){ t+t; }` (outer clause, inner expression). That's where the Form 4 double-`requires` from last piece comes from. This piece focuses on how the clause is used and how constraints participate in overloading. The expression gets its own piece next.
+
+## Where you can attach a constraint
+
+A concept's constraint is not only for free function templates. Function templates, class templates, member functions, even abbreviated `auto` parameters can all be constrained. A combined example:
+
+```cpp
+#include <concepts>
+
+template <typename T>
+concept Numeric = std::integral<T> || std::floating_point<T>;
+
+// 1. function template
+template <Numeric T>
+T square(T x) { return x * x; }
+
+// 2. class template: only instantiates for numeric types
+template <Numeric T>
+struct SafeNumber {
+    T value;
+    SafeNumber(T v) : value(v) {}
+    // 3. a member function can pile on its own constraint
+    SafeNumber& operator+=(Numeric auto other) {
+        value += other;
+        return *this;
+    }
+};
+
+// 4. abbreviated syntax: constraint goes right before auto
+Numeric auto half(Numeric auto x) { return x / 2; }
+```
+
+<OnlineCompilerDemo allow-run
+  title="Where constraints can go: function, class, member, auto"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/constraints_everywhere.cpp"
+  description="The Numeric constraint attached to a function template, a class template, a member function, and abbreviated auto. All four positions compile."
+/>
+
+Run it:
+
+```text
+square(4) = 16
+square(2.5) = 6.25
+SafeNumber(3) + 4 = 7
+half(10) = 5
+```
+
+All four positions compile. Pay attention to the class template in particular. Once you constrain a class template, an instantiation like `SafeNumber<std::string>` that doesn't satisfy `Numeric` fails the constraint right at the declaration, instead of waiting to blow up when you use a member. The constraint pulls "this class is only for numeric types" forward to the moment of instantiation.
+
+## Subsumption: the compiler picks overloads by constraint entailment
+
+Now the main event. Let's write two same-named overloads, one looser and one tighter, and see what the compiler picks.
+
+```cpp
+#include <concepts>
+#include <iostream>
+
+template <typename T>
+concept Animal = requires(T t) { t.eat(); };
+
+template <typename T>
+concept Dog = Animal<T> && requires(T t) { t.bark(); };   // Dog wants one more thing: bark()
+
+void describe(Animal auto) { std::cout << "an animal\n"; }   // loose overload
+void describe(Dog auto)    { std::cout << "a dog\n"; }       // tight overload
+
+struct Cat { void eat() {} };
+struct Pup { void eat() {} void bark() {} };
+
+int main() {
+    describe(Cat{});   // Cat only satisfies Animal
+    describe(Pup{});   // Pup satisfies both Animal and Dog
+}
+```
+
+This is the core excerpt. The full file (including the `Both/C` covered in the conjunction section below) is at [subsumption_overloads.cpp](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/examples/vol4/vol3-metaprogramming-cpp20-23/subsumption_overloads.cpp).
+
+Run it (animal/dog part):
+
+```text
+an animal
+a dog
+```
+
+`Cat` only satisfies `Animal`. There's no second overload to pick, so it goes to the loose one. `Pup` satisfies both `Animal` and `Dog`, but it goes to the **tight overload** `Dog`. That's subsumption at work. `Dog`'s requirement is `Animal<T> && bark requirement`, which folds all of `Animal`'s requirements in. We say **`Dog` subsumes `Animal`**. When both overloads match, the compiler picks the one with the tighter, more specific constraint.
+
+What did this look like in the SFINAE era? You'd use `enable_if` with layer upon layer of "does this member function exist" probing, or reach for tag dispatch. The code doubled in size and still wasn't readable. Concepts hand "which is more specific" to the compiler, computed from the constraint relationship. That is the real reason they change how you write generic code.
+
+## Two constraints that don't subsume each other: ambiguity
+
+Subsumption only sorts things out when one constraint strictly entails the other. If two constraints are independent, neither containing the other, and some type satisfies both, the compiler can't pick.
+
+```cpp
+template <typename T> concept Swimmable = requires(T t) { t.swim(); };
+template <typename T> concept Flyable   = requires(T t) { t.fly(); };
+
+void act(Swimmable auto) { /* ... */ }
+void act(Flyable auto)   { /* ... */ }
+
+struct Duck { void swim() {} void fly() {} };   // satisfies both
+
+int main() { act(Duck{}); }   // neither subsumes the other
+```
+
+```text
+ambiguity.cpp:12:8: error: call of overloaded 'act(Duck)' is ambiguous
+```
+
+`Swimmable` and `Flyable` don't subsume each other, `Duck` satisfies both, and the compiler has no reason to prefer one. It reports ambiguity. The fix is either to add a tight overload `Duck = Swimmable<T> && Flyable<T>` (it subsumes both, so it gets picked), or to write `act<ConcreteType>` explicitly at the call site. The key point: **subsumption only resolves ambiguity when there's a containment relationship. It can't resolve a peer-level tie.**
+
+## Atomic constraints: the real unit that decides subsumption
+
+How did `Dog` subsuming `Animal` get computed above? That brings us to **atomic constraints**. The compiler doesn't look at "which of the names `Dog` and `Animal` contains the other." It breaks each constraint down into minimal, indivisible atomic constraints and looks at set containment.
+
+`concept Dog = Animal<T> && bark requirement`, after normalization, has the atomic constraint set `{ Animal<T>, bark requirement }`. `Animal`'s atomic constraint set is `{ Animal<T> }`. The former is a proper superset of the latter, so `Dog` subsumes `Animal`.
+
+There's a trap here that gets everyone. Let's run it. Intuitively, writing `C2 = C1<T>`, handing one concept to another unchanged, feels like `C2` ought to be more specific than `C1`. Let's try:
+
+```cpp
+template <typename T> concept C1 = std::is_integral_v<T>;
+template <typename T> concept C2 = C1<T>;          // just a rename
+
+void g(C1 auto) { /* ... */ }
+void g(C2 auto) { /* ... */ }
+
+int main() { g(42); }   // int satisfies both C1 and C2
+```
+
+```text
+atomic.cpp:14:15: error: call of overloaded 'g(int)' is ambiguous
+```
+
+Ambiguous. Why? Because `C2 = C1<T>`, after normalization, has the atomic constraint `C1<T>` itself, **identical** to `C1`'s atomic constraint. The two overloads' constraint sets are equal. Neither properly contains the other, neither subsumes, and it falls back to plain ambiguity. Renaming doesn't conjure up a "more specific" relationship. Subsumption wants a **proper superset** of atomic constraints. A name change doesn't affect that.
+
+To make `C2` actually win, you have to give it an atomic constraint beyond `C1`. The `&&` combinator does exactly this:
+
+```cpp
+template <typename T> concept A = requires(T t){ t.a(); };
+template <typename T> concept B = requires(T t){ t.b(); };
+template <typename T> concept C = A<T> && B<T>;   // atomic constraints = { A<T>, B<T> }
+
+void f(A auto) { /* ... */ }
+void f(B auto) { /* ... */ }
+void f(C auto) { /* ... */ }   // C subsumes A, and subsumes B
+
+int main() { struct S{ void a(){} void b(){} } s; f(s); }
+```
+
+```bash
+$ g++ -std=c++20 -Wall -Wextra conjunction.cpp -o conj && ./conj
+C
+```
+
+`C`'s atomic constraint set `{ A<T>, B<T> }` is a superset of both `{ A<T> }` and `{ B<T> }`, so it subsumes `A` and `B`, and the compiler picks `C` out of the three. This spells out the real role of `&&`: it isn't "glue two constraints into a new one." It takes the atomic constraints from both sides and **unions** them into one set.
+
+::: warning Constraints are compared by atoms, not by name
+Subsumption compares the **atomic constraint set** after normalization, not the concept names. `C2 = C1<T>` doesn't make `C2` more specific than `C1`, because their atomic constraints are the same. If you want an overload to win, its atomic constraint set has to be a proper superset of the other, and the usual way to get there is to stack another constraint with `&&`. Remember this, and you won't get tangled in "the names are clearly different, why is it still ambiguous" when you write constrained overload families.
+:::
+
+<OnlineCompilerDemo allow-run
+  title="Subsumption in full: animal/dog plus the conjunction case C"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/subsumption_overloads.cpp"
+  description="Full run of subsumption_overloads.cpp: Cat goes to the loose overload, Pup to the tight one, and Both (satisfying A, B, and C) is picked as C."
+/>
+
+Full run output:
+
+```text
+an animal
+a dog
+C
+```
+
+## A trap: don't use a concept as is_same
+
+`std::same_as` is a concept that leads people astray. You can write `template <std::same_as<int> T>` to pin `T` down to exactly `int`.
+
+```cpp
+template <std::same_as<int> T>
+void only_int(T x) { /* ... */ }
+
+only_int(42);       // fine
+// only_int(3.14);  // fails to compile: double doesn't satisfy same_as<int>
+```
+
+It works, but it's usually bad design. If your function only takes `int`, writing an ordinary non-template function `void only_int(int x)` is clearer, simpler, and saves the compiler one instantiation. The real home for a "type equivalence" constraint like `same_as` is inside a template, requiring a relationship between **two parameters**, like `template <typename A, typename B> requires std::same_as<A, B>`, which says "A and B must be the same type." Using it to lock a single template parameter to one concrete type is the wrong tool.
+
+With concepts in the signature and participating in overloading, you can write generic code that is both clear and able to dispatch. In the next piece we take apart the expression form of `requires`, the one most easily confused, which describes on the spot "what operations a type must provide." It's the foundation of every `requires(T t){ ... }` you've seen above.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/03-requires-expressions.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/03-requires-expressions.md
@@ -1,0 +1,195 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 'The word requires in C++20 is both a clause and an expression, and they are easy to confuse. Taking requires expressions apart. The four kinds of requirements, how to define a concept with one, and the two traps of unevaluated context and hard errors on concrete types.'
+difficulty: intermediate
+order: 3
+platform: host
+prerequisites:
+- 'Constraining Templates with Concepts: Subsumption and Overloading'
+- 'Concepts: Putting Constraints in the Signature'
+reading_time_minutes: 13
+related:
+- 'Concepts: Putting Constraints in the Signature'
+- 'Constraining Templates with Concepts: Subsumption and Overloading'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 泛型
+- concepts
+- 类型安全
+title: 'Requires Expressions, In Depth: The Four Kinds'
+---
+# Requires Expressions, In Depth: The Four Kinds
+
+In the last two pieces, the word `requires` kept showing up, sometimes as a clause, sometimes as an expression. They look the same but do different jobs. This piece takes them fully apart: what a requires expression is, what kinds of requirements it can state, how to use it to describe "what operations a type must provide" on the spot, and two traps that trip people up most. After this piece, every `requires(T t){ ... }` you see will have a clear origin.
+
+## Two kinds of requires: clause and expression
+
+Before going further, put the two same-named things side by side. Everything below builds on this.
+
+| | requires clause (requires-clause) | requires expression (requires-expression) |
+|---|---|---|
+| **What it is** | a syntactic slot that adds a constraint to a template | an expression that evaluates to bool at compile time |
+| **What it looks like** | `requires Numeric<T>` | `requires(T t) { t.size(); }` |
+| **Value** | not a value, it's a constraint declaration | a bool (true / false) |
+| **Where it appears** | after the template parameter list | almost anywhere a bool is needed: in a clause, in a concept definition, in a `static_assert` |
+
+The star of the last piece, subsumption and overload dispatch, was the **clause**. The star of this piece is the **expression**. They often pair up: a clause that contains an expression is `requires requires(T t){ t+t; }`, the double-`requires` you've seen. The outer one is a clause, the inner one is an expression.
+
+## The four kinds of requirements in a requires expression
+
+Inside the braces of a requires expression `requires(params) { ... }`, you can write four different kinds of "requirements." Let's define a `Container` concept and use all four at once:
+
+```cpp
+#include <concepts>
+#include <vector>
+
+template <typename T>
+concept Container = requires(T t) {
+    // 1. simple requirement: the expression must be valid, it just has to compile
+    t.begin();
+    t.end();
+
+    // 2. type requirement: this nested type must exist
+    typename T::value_type;
+
+    // 3. compound requirement: the expression is valid, and the return satisfies a constraint
+    { t.size() } -> std::convertible_to<std::size_t>;
+
+    // 4. nested requirement: another compile-time bool judgment inside
+    requires std::integral<typename T::value_type>;
+};
+
+static_assert(Container<std::vector<int>>);   // vector<int> meets all four
+static_assert(!Container<int>);               // int has no begin/end, fails the first one
+```
+
+These two `static_assert`s are compile-time assertions. If the code compiles, `vector<int>` satisfies `Container` and `int` doesn't. No need to run anything.
+
+Each kind has its use. The simple requirement is the most common. `t.begin();` just asks "can an object of type `T` call `begin()`, and if it compiles, it passes." The type requirement `typename T::value_type;` checks that a nested type exists. It shows up constantly in trait checks on containers and iterators. The compound requirement `{ t.size() } -> std::convertible_to<std::size_t>;` binds "the expression is valid" and "the return type satisfies the constraint" together. It's tighter than checking the call separately and then querying the return type with `decltype`. A compound requirement can also add `noexcept`: `{ t.size() } noexcept -> std::convertible_to<std::size_t>;`, which requires the call to not throw. The nested requirement `requires std::integral<...>;` lets you tuck another concept judgment inside the expression. It fits "once the main requirements hold, also satisfy this extra one."
+
+A side note that's easy to miss: the fourth requirement on `Container` says `value_type` is an integer type, and `std::integral<char>` is **true** (char is in the integer family, same as `integral<bool>` being true in the last piece). So `Container<std::string>` actually satisfies it, because string's `value_type` is char and passes the fourth requirement. If you only want containers whose `value_type` is exactly `int`, swap the fourth line for `std::same_as<typename T::value_type, int>`.
+
+## A requires expression is a bool: it doesn't have to be a named concept
+
+A requires expression evaluates to a bool, so it doesn't only live inside a concept definition. Anywhere you need a compile-time judgment, you can use it directly.
+
+```cpp
+#include <string>
+
+// Drop it straight into a static_assert, no concept needed
+static_assert(requires(std::string s) { s.size(); });   // string has size()
+
+// Use it directly in if constexpr for a compile-time branch
+template <typename T>
+void process(T t) {
+    if constexpr (requires(T x) { x.empty(); }) {
+        std::cout << "has empty()\n";
+    } else {
+        std::cout << "no empty()\n";
+    }
+}
+```
+
+<OnlineCompilerDemo allow-run
+  title="A requires expression as a bool"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/requires_expression.cpp"
+  description="An inline requires expression dropped straight into if constexpr to judge at compile time whether a type has empty(), without defining a concept first."
+/>
+
+Run it:
+
+```text
+has empty()
+no empty()
+```
+
+For a quick check of "does this type have this operation," an inline requires expression is the lightest tool. But note the tradeoff: an inline expression has no name, so it doesn't form a reusable atomic constraint. In the last piece we said overload dispatch relies on named concepts to build entailment. If you want two overloads to dispatch by constraint, you need named concepts (`concept C = requires(...){...}`). Inline expressions can't subsume. So for a check you only use once, an inline expression is fine. For a requirement that has to dispatch or be reused, lift it into a concept.
+
+## Trap one: a requires expression is not evaluated
+
+This is the most counterintuitive trap. The calls written inside a requires expression only **check whether they compile**. They never actually run. Let's run one for proof.
+
+```cpp
+#include <iostream>
+
+int counter = 0;
+int increment() {
+    ++counter;
+    std::cout << "[side effect] increment called\n";
+    return 1;
+}
+
+template <typename T>
+concept MentionsIncrement = requires(T t) {
+    increment();   // only checks "is this call legal", does not evaluate, does not run
+};
+
+int main() {
+    static_assert(MentionsIncrement<int>);   // satisfied: the increment() call is legal
+    std::cout << "concept evaluated, counter = " << counter << "\n";
+    increment();                              // this is the real call
+    std::cout << "after the real call, counter = " << counter << "\n";
+}
+```
+
+<OnlineCompilerDemo allow-run
+  title="A requires expression is unevaluated, counter proof"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/unevaluated.cpp"
+  description="The increment() call inside requires only checks legality, it never runs. After the concept evaluates, counter is still 0, until the real call in main."
+/>
+
+Run it:
+
+```text
+concept evaluated, counter = 0
+[side effect] increment called
+after the real call, counter = 1
+```
+
+Look at the `counter = 0` line. When `MentionsIncrement<int>` gets evaluated, the `increment()` call inside the requires expression **never ran**. Counter is still 0, and the side-effect line didn't print. Only when `main` actually writes `increment()` does counter become 1.
+
+A requires expression belongs to an **unevaluated context**, like `decltype` and `sizeof`. The compiler only cares whether the expressions inside are "type-legal." It generates no call, and it triggers no side effects. Beginners trip on this a lot: they write something inside a requires expression that "looks like it initializes" or "looks like it computes," assume it ran, and nothing happened. Use requires expressions to judge type capability. To actually make code run, you still have to write it in an ordinary function body.
+
+## Trap two: writing a concrete type directly gives a hard error
+
+The second trap is sneakier, and it's the flip side of the first. Suppose we want to test "string doesn't have some method." The intuitive way is to put string into the requires expression as the parameter:
+
+```cpp
+// Intuitive: test the negative case with a concrete string type
+static_assert(!requires(std::string s) { s.nope(); });   // string has no nope
+```
+
+```text
+four_requirements2.cpp:17:44: error: 'std::string' has no member named 'nope'
+```
+
+That's a hard error, not an elegant false. Why? Because a requires expression is "immediately evaluated" for a **concrete type**. The compiler sees the concrete type `std::string s`, goes straight into string to look for `nope`, doesn't find it, and errors hard. It doesn't go through the SFINAE path of "substitution failure returns false." To make it sting more, `requires(int x) { x.foo(); }` reports `request for member 'foo' in 'x', which is of non-class type 'int'`, because a basic type like `int` can't take `.foo()` syntax at all, and parsing fails on the spot.
+
+The fix is to keep the requires expression in a **template context**. The usual move is to wrap it in a concept:
+
+```cpp
+template <typename T> concept HasSize = requires(T t) { t.size(); };
+template <typename T> concept HasNope = requires(T t) { t.nope(); };
+
+static_assert(HasSize<std::string>);    // string has size -> true
+static_assert(!HasNope<std::string>);   // string has no nope -> false, elegant this time
+static_assert(!HasSize<int>);           // int has no size -> false
+```
+
+```bash
+$ g++ -std=c++20 -Wall -Wextra neg_via_concept.cpp -o nvc && echo "all assertions passed"
+all assertions passed
+```
+
+Once it's wrapped in a concept, `T` is a template parameter. Evaluating the requires expression takes the SFINAE-friendly path: a missing member comes out as false, not a hard error. So for negative test cases, wrap them in a named concept. Don't shove concrete types straight into a requires expression.
+
+::: warning The two traps are two sides of one coin
+"Unevaluated" and "hard error on concrete type" both root in when a requires expression gets evaluated. A requires expression is "deferred and SFINAE-friendly" for a template parameter, so it doesn't execute (not evaluated) and returns false on failure. It's "immediate" for a concrete type, so it also doesn't execute, but a failure errors hard. Remember one line: a requires expression only checks "can this compile," it never runs. To make it return false gracefully, keep it in a template context (usually, wrap it as a concept).
+:::
+
+Three things together, the four kinds of requirements, unevaluated, and template context, and you've taken apart the most easily confused word in C++20. In the next piece we look at the template's compile-time power from another direction: before concepts existed, how did template metaprogramming (TMP) do compile-time computation and type deduction with specialization and SFINAE, and how do we migrate those old techniques onto concepts now.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/04-tmp-core-techniques.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/04-tmp-core-techniques.md
@@ -1,0 +1,254 @@
+---
+chapter: 13
+cpp_standard:
+- 17
+- 20
+description: 'For more than a decade before concepts, generic library authors answered type questions with TMP. The internals of type_traits specialization, template recursion, SFINAE and enable_if, the void_t detection idiom, C++17 fold expressions, and how to migrate constraint-style SFINAE onto concepts.'
+difficulty: intermediate
+order: 4
+platform: host
+prerequisites:
+- 'Concepts: Putting Constraints in the Signature'
+- 'Constraining Templates with Concepts: Subsumption and Overloading'
+- 'Requires Expressions, In Depth: The Four Kinds'
+reading_time_minutes: 17
+related:
+- 'Requires Expressions, In Depth: The Four Kinds'
+- 'Compile-Time Strings: NTTP Class Type and fixed_string'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板元编程
+- 编译期计算
+- 泛型
+title: 'TMP Core Techniques: The World Before Concepts'
+---
+# TMP Core Techniques: The World Before Concepts
+
+For three pieces we've been looking at "constraints" under the light of C++20 concepts. But concepts are new, they only entered the standard in 2020. For more than a decade before that, if a generic library author wanted to answer "is this type qualified," they used a completely different mechanism: template metaprogramming (TMP). This piece steps back to look at TMP's core techniques: using specialization for compile-time queries, template recursion for compile-time loops, SFINAE to make the wrong overload quietly back off, `void_t` to detect whether a member exists, and C++17 fold expressions to replace a good chunk of template recursion.
+
+This stuff looks verbose today, but it has not been fully replaced by concepts. Open the standard library source, open Boost, open Chromium's base, and SFINAE and `void_t` are everywhere. Concepts take over "is the type qualified" style constraints, but "compute a value on the type" still needs TMP. So this piece isn't a museum exhibit. It's groundwork you can't skip when reading or writing real generic code.
+
+## The internals of type_traits: specialization is a compile-time if-else
+
+`std::is_pointer_v<int*>` evaluates to `true`, `std::is_pointer_v<int>` to `false`. How does that compile-time judgment work? The answer is almost disappointingly plain: template partial specialization. Let's hand-write an `is_pointer`. The structure is close to what the standard library does:
+
+```cpp
+template <typename T>
+struct is_pointer_impl {
+    static constexpr bool value = false;
+};
+
+template <typename T>
+struct is_pointer_impl<T*> {
+    static constexpr bool value = true;
+};
+
+template <typename T>
+constexpr bool is_pointer_v = is_pointer_impl<T>::value;
+```
+
+The primary template is the fallback, giving every type `false`. The partial specialization matches `T*`, "pointer to some type," and gives `true`. When the compiler instantiates `is_pointer_impl<int*>`, it finds the partial specialization fits better than the primary and picks it. When it instantiates `is_pointer_impl<int>`, no more-specialized version matches, so it falls back to the primary. That's the most basic TMP idiom: **use specialization for compile-time dispatch**, equivalent to an if-else over types.
+
+Run it and compare against the standard library:
+
+<OnlineCompilerDemo allow-run
+  title="Hand-written is_pointer, specialization as compile-time dispatch"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/traits_from_scratch.cpp"
+  description="Primary template defaults to false, partial specialization matches T* and gives true. Result matches std::is_pointer."
+/>
+
+Run it:
+
+```text
+is_pointer_v<int>:    false
+is_pointer_v<int*>:   true
+is_pointer_v<int**>:  true
+is_pointer_v<double*>:true
+与 std::is_pointer 结果一致
+```
+
+The one or two hundred traits in the standard `<type_traits>` (`is_integral`, `is_class`, `remove_const`, `decay`, and so on) are all built on the same pattern at bottom: a primary template plus a set of partial specializations covering various cases. `remove_const_t<const int>` becoming `int` is nothing more than a partial specialization for `const T` with `using type = T` inside. Once you internalize the "specialization is dispatch" model, the `<type_traits>` source stops being intimidating.
+
+## Template recursion: use instantiation as a loop
+
+Type queries aren't enough. TMP can also do arithmetic at compile time. The trick is to unfold a loop into a chain of template instantiations, with a specialization as the base case. The classic example is factorial:
+
+```cpp
+template <unsigned N>
+struct Factorial {
+    static constexpr unsigned value = N * Factorial<N - 1>::value;
+};
+
+template <>
+struct Factorial<0> {
+    static constexpr unsigned value = 1;
+};
+```
+
+The evaluation of `Factorial<5>::value` is the compiler instantiating down a chain at compile time: `Factorial<5>` references `Factorial<4>::value`, `Factorial<4>` references `Factorial<3>`, until it hits the full specialization `Factorial<0>` where `value` is `1`, and the recursion unwinds, multiplying each layer out. This all happens at compile time. At runtime, `Factorial<5>::value` is just the constant `120`, with no function call overhead.
+
+<OnlineCompilerDemo allow-run
+  title="Template recursion computes factorial, specialization is the base case"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/tmp_factorial.cpp"
+  description="Factorial<N> references Factorial<N-1>, until it hits the Factorial<0> full specialization. The value is fixed at compile time."
+/>
+
+Run it:
+
+```text
+Factorial<5>::value  = 120
+Factorial<10>::value = 3628800
+编译期断言全部通过
+```
+
+`static_assert` can assert `Factorial<10>::value == 3628800` at compile time, which means the value was already computed before the program ran. This "template recursion plus a base-case specialization" is the classic TMP loop pattern. It used to do heavy lifting like compile-time sorting, compile-time string handling, and typelist operations. The cost is real: deep instantiation layers, slow builds, and errors that are hard to read. That's exactly why fold expressions were invented.
+
+## SFINAE: let the wrong overload back off gracefully
+
+Traits answer "what is this type." But generic libraries have another problem. I have two overloads, one for integers and one for floating-point. How do I make the compiler **not error, but quietly skip the wrong one** when the argument doesn't fit? The answer is a rule called SFINAE, short for "Substitution Failure Is Not An Error."
+
+The meaning is: when the compiler substitutes template parameters into a signature, if some step of substitution goes wrong (say it produces a nonexistent type like `int::value_type`), it doesn't error immediately. It marks that overload as "substitution failure," silently drops it from the candidate set, and keeps trying others. `std::enable_if` is the workhorse that uses this rule. It hides the constraint inside an extra default template parameter:
+
+```cpp
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+T add_old(T a, T b) {
+    return a + b;
+}
+```
+
+`std::enable_if_t<condition>` only has a nested `type` when the condition is `true`. When the condition is `false`, it's an empty shell. Substituting it in makes the default parameter's type deduction fail, and SFINAE drops the overload. The result: passing `int` matches, passing `std::string` means this overload isn't even a candidate.
+
+SFINAE works, but its error messages are famously torturous. Let's deliberately call that `add_old` with `std::string` and see what GCC 16.1.1 prints (excerpt):
+
+```text
+error: no matching function for call to 'add_old(std::string, std::string)'
+  candidate: 'template<class T, class> T add_old(T, T)'
+    template argument deduction/substitution failed:
+    error: no type named 'type' in 'struct std::enable_if<false, void>'
+```
+
+The heart of the error is `no type named 'type' in 'std::enable_if<false, void>'`. It's about `enable_if`'s internals, the condition was false so there's no `type` member, and it never mentions the thing you actually care about. You have to already understand SFINAE to back out "oh, it's because string isn't an integer." This is exactly the old path concepts kept contrasting with in the first three pieces. Here we see from the mechanism side why it's so hard to read.
+
+## void_t and the detection idiom: the highlight of C++17
+
+The most elegant use of SFINAE is a pattern called the detection idiom, proposed around 2014 by Walter Brown. Its heart is a tool that looks like it does nothing: `std::void_t`.
+
+```cpp
+template <typename...>
+using void_t = void;
+```
+
+`void_t` maps any types to `void`. It has no logic of its own, but paired with partial specialization it does the thing SFINAE-era code found hardest: **elegantly detect whether a type has a given member**. Let's detect "does T have a nested `value_type`":
+
+```cpp
+template <typename T, typename = void>
+struct has_value_type : std::false_type {};
+
+template <typename T>
+struct has_value_type<T, std::void_t<typename T::value_type>> : std::true_type {};
+```
+
+The primary template defaults to inheriting `false_type`. The partial specialization's second template parameter is `std::void_t<typename T::value_type>`. The key is how the compiler picks between the two. When instantiating `has_value_type<std::vector<int>>`, the compiler tries the more-specialized partial first, substituting `T` with `std::vector<int>`, then tries to evaluate `std::void_t<std::vector<int>::value_type>`. `vector<int>` does have `value_type`, substitution succeeds, `void_t` maps it to `void`, the partial's second parameter settles on `void`, which matches the primary's default `void`, the partial wins, and the result is `true_type`. The other way, instantiating `has_value_type<int>`: `int::value_type` doesn't exist, substitution fails, and by the SFINAE rule failure is not an error. The partial is silently dropped, the compiler falls back to the primary, and the result is `false_type`.
+
+Run it:
+
+<OnlineCompilerDemo allow-run
+  title="The void_t detection idiom, detecting a nested type"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/void_t_detection.cpp"
+  description="The primary template inherits false_type. The partial specialization wins via void_t only when substitution succeeds, returning true or false gracefully."
+/>
+
+Run it:
+
+```text
+has_value_type_v<std::vector<int>>: true
+has_value_type_v<std::string>:      true
+has_value_type_v<int>:              false
+```
+
+`void_t` folds what used to be long, ugly SFINAE detection code into two lines of partial specialization. That's why it was brought into the standard in C++17. But one fact has to be said plainly.
+
+::: warning Only void_t made it into the standard, not the whole detection idiom
+Walter Brown wrote three proposals around the detection idiom (N3911, then N4436, then N4502). The last one, N4502, proposed bringing a ready-made toolkit (`std::is_detected`, `std::detected_t`, and friends) into the standard library. That toolkit **was never voted in**. Only `void_t` itself, the atomic building block, made it into C++17. So you won't find `std::is_detected` in the standard library. To use the detection idiom you have to hand-write the two-line partial specialization shown above, or lean on a third-party library like Boost. After concepts arrived, "does some operation exist" can mostly be written more directly as `requires(T t){ t.foo(); }`, so the detection idiom shows up less in new code. But when you read older libraries, it's still everywhere.
+:::
+
+## Fold expressions: kill the recursion boilerplate
+
+Template recursion can compute factorials, but for variadic work like "sum any number of arguments," the recursive style needs a primary template, a recursive case, and a termination specialization. The boilerplate is heavy. C++17 fold expressions cut it out. Compare these two:
+
+```cpp
+// Old way: recursion plus termination
+template <typename T>
+constexpr T sum_rec(T first) { return first; }
+
+template <typename T, typename... Rest>
+constexpr T sum_rec(T first, Rest... rest) {
+    return first + sum_rec(rest...);
+}
+
+// C++17: one fold expression does it
+template <typename... Ts>
+constexpr auto sum_fold(Ts... ts) {
+    return (ts + ...);  // unary right fold
+}
+```
+
+`(ts + ...)` folds the whole parameter pack with `+`. Run it, both writes give the same result:
+
+<OnlineCompilerDemo allow-run
+  title="Variadic recursion vs a C++17 fold expression"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/fold_vs_recursion.cpp"
+  description="The old way needs a primary template, a recursive case, and a termination specialization. A C++17 (ts + ...) fold replaces all of it."
+/>
+
+Run it:
+
+```text
+sum_rec(1,2,3,4):  10
+sum_fold(1,2,3,4): 10
+逗号折叠展开: 1 2.5 hi
+```
+
+That last line, "comma fold expansion," is another common use of folds. With the comma operator, you merge a pack of operations. `(printer(1), printer(2.5), printer("hi"))` expands any number of calls in one line. In variadic contexts it has almost completely replaced the old recursive expansion.
+
+There are four forms of fold. One table is enough:
+
+| Form | Syntax | Meaning (pack a, b, c; initial value e) |
+|---|---|---|
+| Unary right fold | `(pack op ...)` | `(a op (b op c))` |
+| Unary left fold | `(... op pack)` | `((a op b) op c)` |
+| Binary right fold | `(pack op ... op e)` | `(a op (b op (c op e)))` |
+| Binary left fold | `(e op ... op pack)` | `(((e op a) op b) op c)` |
+
+The binary form takes an initial value `e`, mostly to handle the empty-pack case. A unary fold is ill-formed on an empty parameter pack. `(ts + ...)` fails to compile with no arguments, because "nothing" can't be `+`-ed. But three operators have a defined default for empty packs in unary folds: `&&` is `true`, `||` is `false`, and comma is `void()`. So `(... && bs)` compiles even when `bs` is empty. This comes in handy when writing "all of these constraints must hold," and we'll use it again in the comprehensive project.
+
+## Migrating SFINAE onto concepts: old and new for the same need
+
+With all of that in hand, let's weld this piece together with the first three. Same need: "`add` only takes integers." The SFINAE version and the concept version side by side:
+
+```cpp
+// SFINAE (since C++11): the constraint hides in a default template parameter
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+T add_old(T a, T b) { return a + b; }
+
+// concept (C++20): the constraint sits in the signature
+template <typename T>
+    requires std::integral<T>
+T add_new(T a, T b) { return a + b; }
+```
+
+Call both with `std::string`. The concept version points straight at the constraint:
+
+```text
+error: no matching function for call to 'add_new(std::string, std::string)'
+  constraints not satisfied
+  required for the satisfaction of 'integral<T>' [with T = std::__cxx11::basic_string<char>]
+```
+
+Compared with the SFINAE version's `no type named 'type' in 'std::enable_if<false, void>'`, the difference is plain. The concept version speaks like a person, telling you `integral<T>` wasn't satisfied, and substitutes in the concrete type. The `enable_if` version talks about its own internals, and you have to translate it back to "which requirement failed."
+
+So should all SFINAE migrate to concepts? In general, any SFINAE used to "constrain whether a template parameter is qualified" should move to a concept today. The readability and error quality are a step change. For "does some member or operation exist" needs, requires expressions write just as cleanly (`requires(T t){ t.foo(); }`), so new code should migrate too. The case that doesn't need to migrate is SFINAE used as a "type computation building block," like picking one of two types based on a condition. That should use `std::conditional_t`, which has nothing to do with constraints.
+
+Concepts took over the hardest-to-read part of SFINAE, but not all of TMP: specialization for type queries and fold expressions for compile-time folding are still everyday tools. In the next piece we push TMP toward a concrete direction, compile-time string handling, and see how C++20's NTTP class type makes "a string as a template parameter," something that used to be painful, feel natural.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
@@ -9,7 +9,7 @@ platform: host
 prerequisites:
 - 'TMP Core Techniques: The World Before Concepts'
 - 'Concepts: Putting Constraints in the Signature'
-reading_time_minutes: 14
+reading_time_minutes: 12
 related:
 - 'TMP Core Techniques: The World Before Concepts'
 - 'Static Reflection Basics: The Reflection Operator and Splice'

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
@@ -1,0 +1,184 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 'Using a string as a template parameter was hard enough that almost nobody did it before C++17. The const char* as NTTP trap, C++20 P0732 and structural types, the fixed_string idiom, and compile-time hashing as an alternative that does not touch NTTP.'
+difficulty: intermediate
+order: 5
+platform: host
+prerequisites:
+- 'TMP Core Techniques: The World Before Concepts'
+- 'Concepts: Putting Constraints in the Signature'
+reading_time_minutes: 14
+related:
+- 'TMP Core Techniques: The World Before Concepts'
+- 'Static Reflection Basics: The Reflection Operator and Splice'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 编译期计算
+- 模板元编程
+- 类型安全
+title: 'Compile-Time Strings: NTTP Class Type and fixed_string'
+---
+# Compile-Time Strings: NTTP Class Type and fixed_string
+
+The last piece ended on a teaser: using a string as a template parameter. It sounds simple, `template <"hello">`, right, but before C++17 it was hard enough that almost nobody bothered. The C++20 P0732 proposal blew that door open. It let a class type be used as a non-type template parameter (NTTP), and the `fixed_string` idiom is a direct beneficiary. This piece walks from "why it used to be hard" to "how it feels natural now," and along the way explains what the new "structural type" concept actually constrains.
+
+## First, the trouble: const char* as an NTTP before C++20
+
+Before C++20, an NTTP could only be an integer, an enum, a pointer, or a reference. A string had to come in through `const char*`. But `const char*` as a template parameter is a bad fit. Here's the sharpest edge: a string literal **cannot be written directly in the template parameter list**.
+
+```cpp
+template <const char* Name>
+struct Bad {};
+Bad<"hello"> b;   // literal as NTTP, fails to compile
+```
+
+```text
+error: '"hello"' is not a valid template argument for type 'const char*'
+       because string literals can never be used in this context
+```
+
+GCC's wording is blunt: `string literals can never be used in this context`. The reason is that a template argument needs linkage, so the same template instance can be merged across translation units. A string literal has no linkage, so the compiler refuses it outright. To use a `const char*` NTTP, you first have to store the string in a `constexpr` variable with external linkage:
+
+```cpp
+constexpr const char kRed[] = "red";   // an object with linkage
+template <const char* Name>
+struct Tagged { static constexpr const char* name = Name; };
+
+Tagged<kRed> t;   // compiles now
+```
+
+It compiles, but this drags in a second problem. The argument in `Tagged<kRed>` is the **address** of the object `kRed`, not the contents of `"red"`. If two translation units each define a `kRed`, their addresses differ, and `Tagged<kRed>` instantiates two different types. That fights the template intuition that "same argument means same type." Pile on the maintenance cost: every string you want as a template parameter needs a variable declared somewhere outside, and the codebase fills up with these boilerplate variables that exist only to serve the compiler. Together that's why "string as a template parameter" was basically unused before C++20.
+
+## The C++20 fix: P0732 and structural types
+
+P0732 (proposed by Louis Dionne, accepted into C++20) opens a new path: a class type can serve as an NTTP. There's a catch. The class has to be a **structural type**. The core requirement, in two sentences: it has to be a literal class type (constructible and destructible at compile time), and **all of its base classes and all of its non-static data members must be public**. The second part is the line you trip over most when writing code, and we'll demonstrate it later. The intent is to let the compiler decide whether two template arguments are equivalent "by the value of the data members," without calling a user-written `operator==`. Calling user code inside the compile-time machinery of template equivalence would invite trouble.
+
+`fixed_string` is designed around exactly that rule: wrap a string in a struct whose only non-static data member is a public `char` array, and it satisfies structural, so it can be an NTTP. Here's a minimal working version:
+
+```cpp
+template <std::size_t N>
+struct FixedString {
+    char value[N] = {};
+
+    // A literal "abc" has type const char[4] (including \0), which matches const char(&)[N]
+    constexpr FixedString(const char (&str)[N]) {
+        for (std::size_t i = 0; i < N; ++i) value[i] = str[i];
+    }
+
+    constexpr bool operator==(const FixedString& other) const {
+        for (std::size_t i = 0; i < N; ++i) {
+            if (value[i] != other.value[i]) return false;
+        }
+        return true;
+    }
+
+    constexpr const char* c_str() const { return value; }
+};
+
+// CTAD deduction guide: a literal "hello" deduces to FixedString<6> (6 includes the trailing \0)
+template <std::size_t N>
+FixedString(const char (&)[N]) -> FixedString<N>;
+```
+
+One detail worth slowing down on. A string literal like `"hello"` has type `const char[6]`, five characters plus a trailing `\0`. So the `N` deduced by CTAD is 6, and `value[6]` holds the full string and the `\0`. The constructor takes `const char(&str)[N]`, a reference to an array, so `N` is deduced from the literal's size. No need to write it by hand.
+
+::: warning operator== does not participate in template equivalence
+The `operator==` we wrote for `FixedString` only gets called when "comparing two objects at runtime" or "manually comparing in an `if constexpr`." It has **nothing to do with template argument equivalence**. When the compiler decides whether `Named<"abc">` and another `Named<"abc">` are the same type, it follows the structural rule: compare the `value` arrays byte by byte. It calls no user code. In other words, delete the `operator==` entirely, and `Named<"abc">` and `Named<"abc">` are still the same type, while `Named<"abc">` and `Named<"abd">` are still two different types. Get this wrong and every piece of NTTP-class-type code you read will feel twisted.
+:::
+
+## fixed_string in action: a string as a template parameter
+
+With the design done, you can drop `FixedString` straight into `template <...>`:
+
+```cpp
+template <FixedString S>
+struct Named {
+    static constexpr auto name = S;
+};
+
+template <FixedString S>
+void greet() {
+    std::cout << "hello, " << S.c_str() << "\n";
+}
+```
+
+Run it:
+
+<OnlineCompilerDemo allow-run
+  title="fixed_string as an NTTP, a string baked into the type"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/nttp_fixed_string.cpp"
+  description="FixedString is structural and goes straight into a template parameter. The string is baked into the type itself."
+/>
+
+Run it:
+
+```text
+world
+hello, templates
+编译期字符串比较断言通过
+```
+
+`Named<"world">{}` instantiates a type whose `name` member holds `"world"` at compile time. `greet<"templates">()` does the same: the string `"templates"` is baked into the type itself. This was nearly impossible in C++17. Now one template parameter solves it.
+
+Now the compile-time string comparison. `FixedString{"abc"} == FixedString{"abc"}` holds inside a `static_assert`, which means the comparison runs entirely at compile time and produces a constant bool. This matters in "dispatch by string at compile time" scenarios. Pick an implementation based on a configuration string. In the past you'd route through an enum. Now you can speak in string literals directly.
+
+## The structural limit: why you can't throw any old class at an NTTP
+
+P0732 opened a door, but only the structural one. Let's try a deliberate counterexample: a class with a private data member, shoved into an NTTP.
+
+```cpp
+class Secret {
+    int x;   // private (members of a class are private by default)
+public:
+    constexpr Secret(int v) : x(v) {}
+};
+
+template <Secret S>
+struct Bad {};
+Bad<Secret{1}> bad;
+```
+
+```text
+error: 'Secret' is not a valid type for a template non-type parameter
+       because it is not structural
+note: 'Secret::x' is not public
+```
+
+The error states the rule plainly: `not structural`, because `Secret::x` isn't public. The compiler needs to "look at the values member by member" to decide whether two NTTPs are equivalent. If a member is private, the compiler can't reach it that directly (access semantics get involved), so it draws a hard line and requires all public. So the first thing to check when you want a custom class as an NTTP is whether its data members are all exposed. Forget a class with a `std::string` member, too. `std::string` itself has private data, so it isn't structural, and that disqualifies the whole class.
+
+## Compile-time hashing: you don't always need NTTP
+
+One thing to add here: not every "process strings at compile time" need requires baking the string into a type. A `constexpr` function is enough for many cases, like computing a string hash at compile time:
+
+```cpp
+constexpr std::uint64_t fnv1a_64(std::string_view s) {
+    std::uint64_t hash = 14695981039346656037ULL;  // FNV offset basis
+    for (char c : s) {
+        hash ^= static_cast<std::uint64_t>(static_cast<unsigned char>(c));
+        hash *= 1099511628211ULL;  // FNV prime
+    }
+    return hash;
+}
+```
+
+<OnlineCompilerDemo allow-run
+  title="Compile-time FNV-1a string hash"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/compile_time_hash.cpp"
+  description="A pure constexpr function, no NTTP. The hash is computed at compile time and fits into a static_assert."
+/>
+
+Run it:
+
+```text
+fnv1a_64("hello") = 11831194018420276491
+fnv1a_64("world") = 5717881983045765875
+编译期哈希断言通过
+```
+
+`fnv1a_64("hello")` is computed at compile time. You can put it in a `static_assert`, use it as a `switch` `case` (the hash is a constant), or do compile-time string matching. This path never touches NTTP, and it's more general: `std::string_view` accepts any string source. So here's the plain decision rule. When you need to bake a string into a type, have it participate in overloading, or use it as a type tag, reach for `fixed_string` NTTP. When you just want to compute a result on a string at compile time, a `constexpr` function is enough. Don't drag in NTTP.
+
+In the next piece we look ahead to C++26. Static reflection (P2996) is about to turn "enum to string" and "look up a type by name," things that today need `fixed_string` plus a pile of template boilerplate, into built-in language capabilities.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
@@ -9,7 +9,7 @@ platform: host
 prerequisites:
 - 'Compile-Time Strings: NTTP Class Type and fixed_string'
 - 'TMP Core Techniques: The World Before Concepts'
-reading_time_minutes: 15
+reading_time_minutes: 11
 related:
 - 'Compile-Time Strings: NTTP Class Type and fixed_string'
 - 'Template Instantiation Control: extern template and Compile Time'

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
@@ -1,0 +1,152 @@
+---
+chapter: 13
+cpp_standard:
+- 26
+description: 'P2996 static reflection in C++26 makes compile-time introspection a built-in language capability. The reflection operator, splice, identifier_of and members_of, template for iteration, and enum-to-string as the killer use case. Includes real output run on Godbolt clang-p2996 and an honest note that mainstream compilers do not support it yet.'
+difficulty: advanced
+order: 6
+platform: host
+prerequisites:
+- 'Compile-Time Strings: NTTP Class Type and fixed_string'
+- 'TMP Core Techniques: The World Before Concepts'
+reading_time_minutes: 15
+related:
+- 'Compile-Time Strings: NTTP Class Type and fixed_string'
+- 'Template Instantiation Control: extern template and Compile Time'
+tags:
+- host
+- cpp-modern
+- advanced
+- 编译期计算
+- 模板元编程
+- 类型安全
+title: 'Static Reflection Basics: The Reflection Operator and Splice'
+---
+# Static Reflection Basics: The Reflection Operator and Splice
+
+The last piece ended on a teaser: C++26 reflection is about to turn "enum to string" boilerplate into a built-in language capability. This piece cashes that in. Reflection is the ability of a program to **introspect** its own structure at compile time: which members a class has, which values an enum has, what a function signature looks like. C++ waited over twenty years for this capability, until the P2996 proposal was voted into the C++26 working draft at the WG21 Sofia meeting in June 2025. This piece explains the reflection operator, splice, a few core APIs, and two of the clearest use cases: walking a struct's members, and enum to string.
+
+::: warning This is C++26. Mainstream compilers can't run it yet
+P2996 made it into the C++26 draft, but the implementation story is early. As of July 2026, neither GCC nor MSVC ships it. The only things that can run it are Bloomberg's open-source clang-p2996 experimental fork and EDG's preview. The local GCC 16.1.1 and clang 22.1.8 on this machine both fail. Tested directly, GCC with the `-freflection` flag and an empty `<meta>` header still reports `expected primary-expression before '^'` on `^^Point`. Clang doesn't recognize `-freflection-latest` at all. So every run output in this piece was produced on Godbolt's `clang_bb_p2996` (Bloomberg branch trunk-20260701), compiled with `-std=c++2c -freflection-latest`. To verify by hand, go to Godbolt and pick that compiler.
+:::
+
+## The reflection operator ^^ and the splice [: :]
+
+The core of P2996 is two new syntax forms. The first is the reflection operator `^^`. It acts on a type or a value and produces a compile-time value of type `std::meta::info`. The compiler can use it to look up that thing's structure.
+
+```cpp
+#include <meta>
+
+struct Point { int x; int y; };
+
+constexpr auto refl = ^^Point;   // refl is a std::meta::info, pointing at the type Point
+```
+
+`^^Point` evaluates to a compile-time `info` value. You can read it as "metadata about the type `Point`." Once you hold this `info`, you can ask "what's your name" and "what members do you have."
+
+The second form is the splice, written `[: refl :]`. It glues an `info` back into the original type or value. `^^` turns a type into an `info`, and `[: :]` turns an `info` back into a type. The two are inverse operations. In the enum example below you'll see `[:enumerator:]` splice an enumerator's `info` back into the enumerator value itself, used for comparison.
+
+## Core APIs: identifier_of, members_of, access_context
+
+Once you have an `info`, P2996 provides a set of query functions under the `std::meta` namespace. Here are the ones this piece uses:
+
+- `identifier_of(info)` returns the entity's name as a `string_view` (before R13 it was called `name_of`, later renamed).
+- `nonstatic_data_members_of(type_info, access_context)` returns a `vector<info>` holding all the non-static data members of the type.
+- `enumerators_of(enum_info)` returns all enumerators of an enum.
+
+The `access_context::current()` argument was added in P2996R10. It tells reflection "look up members with the current access rights." After all, private members aren't visible to just anyone. You have to pass it in every time you call a member-query function. Verbose, but necessary.
+
+There's also a part you can't skip, called `define_static_array`. The P2996 query functions return a `constexpr std::vector`, and a `vector`'s memory is on the heap. A "heap pointer" can't serve as a compile-time constant inside a template. `define_static_array` materializes the vector's contents into static storage and returns a span that can be iterated at compile time. It sounds convoluted, but any time you want to walk a query result with `template for`, you have to wrap it in this.
+
+## template for: walk reflection results at compile time
+
+The number of things reflection returns is known at compile time (a struct's member count is fixed at compile time), but a traditional `for` can't iterate over "types." P1306's expansion statement (`template for`) was built for this. It expands over a compile-time-known set of values, and each iteration's variable is a real compile-time constant, usable in a type position.
+
+```cpp
+template for (constexpr auto member : members) {
+    std::cout << "  " << std::meta::identifier_of(member) << "\n";
+}
+```
+
+Note it's `template for`, not `for`, and the loop variable is declared `constexpr auto`. The loop fully unrolls at compile time, equivalent to writing each member's `cout` statement by hand.
+
+## Use case one: walk a struct's members
+
+Stitch the parts together and you get a reflection version of "print every member name of a struct." Full code:
+
+```cpp
+#include <meta>
+#include <iostream>
+
+struct Point {
+    int x;
+    int y;
+};
+
+int main() {
+    using namespace std::meta;
+    constexpr auto refl = ^^Point;
+    constexpr auto ctx = access_context::current();
+    // define_static_array materializes the vector to static storage, so template for compiles
+    constexpr auto members = define_static_array(nonstatic_data_members_of(refl, ctx));
+
+    std::cout << identifier_of(refl) << "\n";
+    template for (constexpr auto member : members) {
+        std::cout << "  " << identifier_of(member) << "\n";
+    }
+}
+```
+
+Run it on Godbolt's clang_bb_p2996 (local compilers can't, see the warning at the top):
+
+```text
+Point
+  x
+  y
+```
+
+No hardcoded strings anywhere in this code. The name `Point` and the member names `x` and `y` were all queried by the compiler from the type itself. Add a field to the struct, rename one, and the output follows automatically without changing a line of code. That's the value of reflection. It erases the seam between "the type definition" and "the code that processes the type."
+
+## Use case two: enum to string
+
+The standout use case for reflection is turning an enumerator into its name. Before reflection, you either hand-wrote a `switch` mapping each enumerator to a string (this boilerplate is everywhere in C++ codebases) or leaned on a third-party library like magic_enum, which sneaks it in by parsing `__PRETTY_FUNCTION__`. Reflection turns it into a few direct lines:
+
+```cpp
+#include <meta>
+#include <iostream>
+#include <string_view>
+
+enum class Color { Red, Green, Blue };
+
+template <typename E>
+constexpr std::string_view enum_to_string(E value) {
+    using namespace std::meta;
+    constexpr auto enumerators = define_static_array(enumerators_of(^^E));
+    template for (constexpr auto enumerator : enumerators) {
+        if (value == [:enumerator:]) {
+            return identifier_of(enumerator);
+        }
+    }
+    return "<unknown>";
+}
+
+int main() {
+    std::cout << enum_to_string(Color::Red) << "\n";
+    std::cout << enum_to_string(Color::Green) << "\n";
+    std::cout << enum_to_string(Color::Blue) << "\n";
+}
+```
+
+```text
+Red
+Green
+Blue
+```
+
+Worth breaking down. `enumerators_of(^^E)` gets the `info` list of all of enum `E`'s enumerators. `template for` looks at each one. `[:enumerator:]` splices the current `info` back into the enumerator value itself, then compares it with the `value` passed in. On a match, `identifier_of` returns the name. The whole thing unrolls at compile time. At runtime there's only a chain of comparisons. No string parsing, no table lookup overhead.
+
+This template works for any enum. Add a new enumerator and `enum_to_string` supports it automatically, no switch to maintain. Compare that with the lengths we went to in the last piece to bake a string into a type (`fixed_string`, structural, CTAD). Reflection turns "names" from something you have to haul around back into information the compiler already holds. You just ask for it.
+
+## Still worth the wait
+
+P2996 delivers far more than these two. Look up a type by name, annotate types (annotations), auto-generate serialization code, map fields from struct to struct. The work that used to need heavy code generators or stacks of macros, reflection can do inside the language. But only once compilers catch up. The Bloomberg clang-p2996 used in this piece is a "highly experimental" fork, and its README says plainly: don't use it for anything headed to production. Until GCC and MSVC actually ship, reflection is mostly a "see the future" state. Worth learning, because the API design has stabilized (R13 was voted in), and once compilers arrive you'll use it directly. Not worth pushing into production code today. In the next piece we go back to something you can use right now: how to control template instantiation, and how to treat build time.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
@@ -1,0 +1,151 @@
+---
+chapter: 13
+cpp_standard:
+- 11
+- 14
+- 17
+description: 'Templates instantiate implicitly by default, and every translation unit generates its own copy of the same code. How explicit instantiation definitions and extern template declarations concentrate instantiation in one place, with an honest look at the real compile-time payoff, which small projects cannot measure but large ones accumulate.'
+difficulty: intermediate
+order: 7
+platform: host
+prerequisites:
+- 'TMP Core Techniques: The World Before Concepts'
+- 'Concepts: Putting Constraints in the Signature'
+reading_time_minutes: 14
+related:
+- 'Static Reflection Basics: The Reflection Operator and Splice'
+- 'Templates and Exception Safety: move_if_noexcept and Reallocation'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 编译期计算
+- 工具链
+title: 'Template Instantiation Control: extern template and Compile Time'
+---
+# Template Instantiation Control: extern template and Compile Time
+
+The last piece ended by saying we'd come back to something you can use today. Templates gave C++ zero-cost abstraction, but they brought a less glamorous side effect: compile time. If a template gets used with the same type argument in a dozen translation units, the compiler may faithfully instantiate it in all dozen. C++11 gave us a tool to manage this: `extern template`. This piece explains the two ways to control template instantiation (explicit instantiation definitions and extern template declarations), and gives an honest look at how much they actually help compile time.
+
+## Implicit instantiation: generated on use, once per translation unit
+
+Templates default to **implicit instantiation**. You use `Heavy<int>` somewhere, and the compiler generates the members of `Heavy<int>` you used, right there in that translation unit. The mechanism is "on demand," and unused members aren't generated. So far so good. The problem is that it happens **once per translation unit**.
+
+Picture a project with `use_a.cpp` and `use_b.cpp`, both using `Heavy<int>`. Compiling `use_a.cpp` instantiates a copy of `Heavy<int>` into `use_a.o`. Compiling `use_b.cpp` instantiates another copy into `use_b.o`. At link time, the linker sees `Heavy<int>::compute` defined in both `.o` files. It relies on the ODR (one definition rule) and the "weak symbol" status of templates to merge them into one. At runtime there's only one copy, no problem. But **the compile work was done twice**. That's the itch `extern template` wants to scratch.
+
+## Explicit instantiation definition: concentrate instantiation in one place
+
+To manage this, you first need an **explicit instantiation definition**. The syntax starts with `template`, followed by a concrete template instance:
+
+```cpp
+#include "heavy_template.h"
+
+template struct Heavy<int>;   // instantiate every member of Heavy<int> in this translation unit
+```
+
+This line says: "in this `.cpp`, please instantiate all of `Heavy<int>`'s member functions, properly." It usually lives in a file like `explicit_inst.cpp`, dedicated to "centralized instantiation."
+
+## extern template: tell other translation units "don't generate"
+
+Centralized instantiation alone isn't enough. Other translation units don't know about it and keep instantiating on their own. So you pair it with an **explicit instantiation declaration**, which is `extern template`:
+
+```cpp
+#include "heavy_template.h"
+
+extern template struct Heavy<int>;   // Heavy<int> is instantiated elsewhere, don't generate here
+```
+
+This line tells the compiler: "`Heavy<int>` is already instantiated in another translation unit. Don't generate code here, just use it." That translation unit skips the instantiation work, and at link time it finds the definition in `explicit_inst.o`.
+
+Used together, "instantiate in every TU" collapses into "instantiate in one TU, everyone else references it." Let's verify this mechanism by running it.
+
+## In practice: how the mechanism runs
+
+A minimal multi-file project. `heavy_template.h` defines the template. `use_a.cpp` does it the old way, implicit instantiation. `use_b.cpp` uses `extern template`. `explicit_inst.cpp` provides the explicit instantiation definition. `main.cpp` ties it together:
+
+```cpp
+// heavy_template.h
+#pragma once
+template <typename T>
+struct Heavy {
+    T value;
+    explicit Heavy(T v) : value(v) {}
+    T compute(T x) const {
+        T acc = value;
+        for (int i = 0; i < 10; ++i) acc = acc * x + value;
+        return acc;
+    }
+};
+```
+
+```cpp
+// use_b.cpp: extern template suppresses instantiation
+#include "heavy_template.h"
+#include <iostream>
+extern template struct Heavy<int>;   // instantiated elsewhere, don't generate here
+void use_b() {
+    Heavy<int> h{99};
+    std::cout << "use_b: " << h.compute(3) << "\n";
+}
+```
+
+```cpp
+// explicit_inst.cpp: centralized explicit instantiation
+#include "heavy_template.h"
+template struct Heavy<int>;
+```
+
+Compile, link, run (`use_a.cpp` is structured the same as `use_b.cpp` but without the extern line):
+
+```bash
+$ g++ -std=c++20 -Wall -Wextra -c use_a.cpp use_b.cpp explicit_inst.cpp main.cpp
+$ g++ use_a.o use_b.o explicit_inst.o main.o -o demo && ./demo
+use_a: 85974
+use_b: 8768727
+```
+
+Four object files compile cleanly, the link passes, the program runs. The mechanism works.
+
+More interesting is "what happens if you don't provide the explicit instantiation definition." Drop `explicit_inst.cpp`, leaving only `use_b.cpp` (with its extern declaration) and `main.cpp`:
+
+```text
+/usr/bin/ld: use_b.o: in function `use_b()':
+undefined reference to `Heavy<int>::Heavy(int)'
+undefined reference to `Heavy<int>::compute(int) const'
+```
+
+The linker can't find the constructor or `compute` for `Heavy<int>` and reports undefined reference. This error states the `extern template` contract plainly. You declared "the definition is elsewhere," so you'd better actually instantiate that definition in some translation unit, or it's an empty promise. One more thing to remember when using them together: any translation unit that doesn't carry the extern declaration (like `use_a.cpp` here) still implicitly instantiates its own copy. `extern template` means "this TU doesn't generate," not "generate only once globally."
+
+## The compile-time payoff: don't buy the "optimizes compile time" slogan without checking
+
+Whenever `extern template` comes up, almost everyone says it "reduces compile time." True in principle. But how much it actually saves is worth measuring. GCC has a `-ftime-report` flag that prints per-phase timings after compiling, including a dedicated `template instantiation` line. First, a small file:
+
+```text
+$ g++ -std=c++20 -c -ftime-report use_b_noextern.cpp   # implicit instantiation version
+ template instantiation             :   0.08 ( 26%)    14M ( 23%)
+```
+
+Template instantiation eats about a quarter of total compile time. Sounds like `extern template` should help. Let's compare: the same `use_b.cpp`, one version with the extern declaration (no instantiation of `Heavy<int>`), one without (implicit), three runs each, looking at the `template instantiation` line.
+
+| File | 3 runs of template instantiation |
+|---|---|
+| `use_b.cpp` (extern, no instantiation) | 0.08 / 0.07 / 0.05 |
+| `use_b_noextern.cpp` (implicit instantiation) | 0.07 / 0.05 / 0.05 |
+
+The difference is entirely inside the noise. Nothing to measure. To rule out "the template is too light," let's make it heavier. Three groups of 80-deep recursive metafunctions (Fibonacci, triangular, Lucas) inside the template. Instantiating `Big<int>` drags in about 240 template specializations. Three runs each again:
+
+| File | 3 runs of template instantiation |
+|---|---|
+| `big_b.cpp` (extern) | 0.08 / 0.07 / 0.05 |
+| `big_b_noextern.cpp` (240 specializations dragged in) | 0.07 / 0.05 / 0.05 |
+
+Still can't measure it. Modern compilers instantiate this kind of "pure type computation" template so fast that the work, in the tens of microseconds, drowns in the noise of parsing and optimization.
+
+So when does `extern template` actually save time? In **large projects, where dozens of translation units repeatedly instantiate the same heavy template**. Heavy here doesn't mean the pure TMP recursion in our example. It means templates whose instantiation drags in a big slice of the standard library, say a generic component that uses `std::variant` and a pile of algorithms, used with the same type argument across twenty `.cpp` files. Twenty repeated instantiations add up to something visible. There, `extern template` compresses twenty into one and the payoff is real. So the decision to use `extern template` hinges on "absolute cost of one instantiation" times "number of repeating translation units." Both have to be large for it to matter. Adding `extern template` to a light template that gets used two or three times in a small project is pure boilerplate. Call it off.
+
+## One word on other ways to treat compile time
+
+If your goal is "make builds faster," `extern template` is rarely the highest-leverage move. The tactics that pay off more often: use forward declarations instead of unnecessary `#include`s, split a template's declaration and definition into separate headers to shrink the instantiation surface, use precompiled headers (PCH), and C++20 modules. Modules redefine "how translation units share code" from the ground up. They're the root fix, though toolchain support is still being polished. `extern template` is a small wrench in this toolkit. It has its place, but it isn't the main tool.
+
+In the next piece we see how templates and exceptions get tangled up: why `vector` cares about the element type's `noexcept` during reallocation, and how `move_if_noexcept` mediates between "performance" and "exception safety."

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
@@ -11,7 +11,7 @@ platform: host
 prerequisites:
 - 'TMP Core Techniques: The World Before Concepts'
 - 'Concepts: Putting Constraints in the Signature'
-reading_time_minutes: 14
+reading_time_minutes: 11
 related:
 - 'Static Reflection Basics: The Reflection Operator and Splice'
 - 'Templates and Exception Safety: move_if_noexcept and Reallocation'

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
@@ -1,0 +1,167 @@
+---
+chapter: 13
+cpp_standard:
+- 11
+description: 'The line where templates and exceptions tangle. The three exception-safety levels, noexcept as a contract, how move_if_noexcept falls back to copy when rollback may be needed, how vector reallocation preserves the strong guarantee, and how conditional noexcept propagates the truth about whether something throws.'
+difficulty: intermediate
+order: 8
+platform: host
+prerequisites:
+- 'TMP Core Techniques: The World Before Concepts'
+- 'Template Instantiation Control: extern template and Compile Time'
+reading_time_minutes: 14
+related:
+- 'Template Instantiation Control: extern template and Compile Time'
+- 'Comprehensive Project: A mini-STL Algorithm Library with Concepts'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 类型安全
+- 内存管理
+title: 'Templates and Exception Safety: move_if_noexcept and Reallocation'
+---
+# Templates and Exception Safety: move_if_noexcept and Reallocation
+
+The last piece ended on a teaser: why does `vector` reallocation care about the element type's `noexcept`. This piece takes that line all the way. Templates and exceptions look unrelated, but the moment you write a container or a generic algorithm they collide in places like "should reallocation move or copy." The core tools are two: `std::move_if_noexcept` and conditional `noexcept`. Understand them, and you understand why everyone insists "mark your move constructor `noexcept` if you possibly can."
+
+## First, the exception-safety levels
+
+Exception safety has a few conventional guarantees. Quick pass, since we mostly use the first two.
+
+- **Basic guarantee**: the function either succeeds or throws, but even if it throws it leaks no resources and leaves no object in a corrupted state.
+- **Strong guarantee**: the function either succeeds or "acts as if it was never called," rolling the whole program state back to before the call.
+- **No-throw guarantee** (`noexcept`): the function promises not to throw.
+
+The strong guarantee is much stricter than the basic one. It demands "rollback." The thread of this piece is that `vector` reallocation wants to keep the strong guarantee, and that goal directly decides whether it moves or copies elements.
+
+## noexcept is a contract to the caller
+
+The `noexcept` keyword is often misread as "I'll try not to throw." What it really means is "I promise not to throw," and if the function does throw, the program goes straight to `std::terminate`, no unwinding, no propagation. So `noexcept` isn't written for the function itself. It's a contract for **the caller**. The caller sees `noexcept` and can optimize freely.
+
+The optimization that matters most for this piece is that a `noexcept` move can be used where "no mid-step failure" is required. `vector` reallocation is exactly such a case. If your move constructor is marked `noexcept`, `vector` dares to move during reallocation. If it isn't, `vector` won't risk it and will copy instead. We'll run this difference below.
+
+## move_if_noexcept: fall back to copy when rollback may be needed
+
+C++11 ships a tool, `std::move_if_noexcept`, that folds the tension between "move" and "the strong guarantee" into one function. The behavior is plain. If `T`'s move constructor is `noexcept`, it returns an rvalue reference (move). Otherwise it returns a const lvalue reference (copy).
+
+```cpp
+// The gist (the standard library's real implementation is equivalent to this check)
+template <typename T>
+conditional_t<is_nothrow_move_constructible_v<T> && !is_lvalue_reference_v<T>,
+              T&&, const T&>
+move_if_noexcept(T& x) noexcept;
+```
+
+Why do we need this? Picture an operation "that may need to roll back after moving." Move a batch of elements from old memory to new memory, and halfway through, a move throws. If you were moving, the elements being moved may already be half-pulled-out of the old memory, the state is wrecked, and rollback is impossible. The strong guarantee is gone. If you were copying, when a copy throws, the original elements in the old memory were never touched. Rollback is "free the new memory," clean. So in "rollback-possible" situations, if move isn't safe enough you fall back to copy. That's what `move_if_noexcept` is for. Let's measure it:
+
+```cpp
+struct NothrowMove {
+    int* p;
+    explicit NothrowMove(int v) : p(new int(v)) {}
+    NothrowMove(const NothrowMove& o) : p(new int(*o.p)) { std::cout << "    copy\n"; }
+    NothrowMove(NothrowMove&& o) noexcept : p(o.p) { o.p = nullptr; std::cout << "    move\n"; }
+};
+
+struct ThrowingMove {
+    int* p;
+    explicit ThrowingMove(int v) : p(new int(v)) {}
+    ThrowingMove(const ThrowingMove& o) : p(new int(*o.p)) { std::cout << "    copy\n"; }
+    ThrowingMove(ThrowingMove&& o) noexcept(false) : p(o.p) { o.p = nullptr; std::cout << "    move\n"; }
+};
+```
+
+<OnlineCompilerDemo allow-run
+  title="move_if_noexcept: move or copy based on noexcept"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/move_if_noexcept_demo.cpp"
+  description="NothrowMove moves, ThrowingMove falls back to copy. See how move_if_noexcept decides based on noexcept."
+/>
+
+Run it:
+
+```text
+is_nothrow_move_constructible:
+  NothrowMove:  true
+  ThrowingMove: false
+move_if_noexcept on NothrowMove (should move):
+    [NothrowMove] moved
+move_if_noexcept on ThrowingMove (should copy):
+    [ThrowingMove] copied
+```
+
+`NothrowMove`'s move is `noexcept`, so `move_if_noexcept` yields an rvalue reference and moves. `ThrowingMove`'s move is marked `noexcept(false)`, it may throw, so `move_if_noexcept` falls back to a const reference and copies. That's the "move or copy based on `noexcept`" behavior.
+
+## How vector reallocation keeps the strong guarantee
+
+When `std::vector` runs out of room and you `push_back` again, it allocates a larger block, moves the old elements over, and frees the old memory. The "move over" uses `move_if_noexcept`. Let's see the copy/move calls during reallocation for different element types:
+
+<OnlineCompilerDemo allow-run
+  title="vector reallocation move vs copy, the strong guarantee"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/vector_realloc.cpp"
+  description="During reallocation NothrowMove is moved, ThrowingMove is copied. The cost vector pays to keep the strong exception guarantee."
+/>
+
+Run it:
+
+```text
+vector<NothrowMove> reserved 2, push a third to trigger reallocation:
+  >>> during reallocation (move is noexcept, should move):
+    move
+    move
+
+vector<ThrowingMove> reserved 2, push a third to trigger reallocation:
+  >>> during reallocation (move may throw, should copy to keep the strong guarantee):
+    copy
+    copy
+```
+
+`NothrowMove`'s move is `noexcept`, so reallocation moves, fast and non-throwing. `ThrowingMove`'s move may throw, so `vector` doesn't dare and copies. Copy is slower than move (it deep-copies what `int*` points at), but that's the cost of keeping the strong guarantee: if a copy throws midway, the elements in old memory are untouched, and `vector` can roll back to the pre-reallocation state.
+
+::: warning If your move constructor isn't noexcept, vector will copy
+This is the most practical lesson of the piece. Many beginners write a class's move constructor, think "it won't throw anyway," and skip `noexcept`. The result: that class goes into a `vector`, and every reallocation copies it instead of moving. The performance of move is thrown away, and the compiler gives you no warning. Remember the rule: for move construction and move assignment, if you're sure they don't throw (usually they just shuffle pointers and a few primitives), always add `noexcept`. This isn't style. It's a real performance switch.
+:::
+
+Not every move can be `noexcept`, of course. If a move has to allocate inside (say, moving an element of a `std::vector`, which may need to allocate a new `vector`), allocation can throw, so you can't blindly mark it. The standard library's `std::vector` has a `noexcept` move constructor because it only steals the other's internal pointers, no allocation. The test is plain: what does the move do, and could any of it throw.
+
+## Conditional noexcept: propagate whether the underlying operation throws
+
+A template function doesn't know whether the type `T` it operates on might throw. But it can "inherit" that information through **conditional noexcept**: `noexcept(noexcept(expression))`. The outer `noexcept` is the specifier. The inner `noexcept(...)` is the operator, evaluated at compile time, asking "is this expression `noexcept`." Together: "my function's `noexcept`-ness equals the underlying expression's `noexcept`-ness."
+
+```cpp
+// No noexcept marked: the caller has to assume it may throw
+template <typename T>
+void uncond_op(T& x) {
+    T tmp(std::move(x));
+    x = std::move(tmp);
+}
+
+// Conditional noexcept: inherit whether T's move construction is noexcept
+template <typename T>
+void cond_op(T& x) noexcept(noexcept(T(std::move(x)))) {
+    T tmp(std::move(x));
+    x = std::move(tmp);
+}
+```
+
+Run it and see how both writes look to the caller:
+
+<OnlineCompilerDemo allow-run
+  title="Conditional noexcept: propagate whether the underlying throws"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/noexcept_propagation.cpp"
+  description="A template with no noexcept is conservatively assumed to throw. noexcept(noexcept(...)) makes noexcept-ness follow the underlying operation."
+/>
+
+Run it:
+
+```text
+uncond_op<NoThrowMove> noexcept: false
+cond_op<NoThrowMove> noexcept:   true
+cond_op<ThrowMove> noexcept:     false
+```
+
+`uncond_op`, even with a `noexcept` move underneath, reports `false` because it isn't marked. It threw the information away. `cond_op` uses conditional noexcept to pass the truth up: `noexcept` when the underlying move is, `false` when the underlying move may throw. This matters when writing generic containers and algorithms. If your `swap`, `move`, or `emplace` operations don't use conditional noexcept, the whole call chain misreports "actually `noexcept`" operations as "may throw." A downstream container checks and falls back to copy, and the move optimization is lost.
+
+## Tying it together
+
+The pieces in this article string along one logic. `noexcept` is a contract to the caller that says "I don't throw." `move_if_noexcept` uses that contract to pick move or copy in "rollback-possible" situations. `vector` reallocation is exactly such a situation, so it decides move or copy based on whether the element's move is `noexcept`. Conditional `noexcept` lets a template function propagate the underlying `noexcept`-ness upward. So a `noexcept` annotation that looks like "just a style choice" is actually the key to whether move performance gets delivered. In the next piece we pool these metaprogramming skills and build a mini-STL algorithm library constrained by concepts, as the closing project.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
@@ -9,7 +9,7 @@ platform: host
 prerequisites:
 - 'TMP Core Techniques: The World Before Concepts'
 - 'Template Instantiation Control: extern template and Compile Time'
-reading_time_minutes: 14
+reading_time_minutes: 12
 related:
 - 'Template Instantiation Control: extern template and Compile Time'
 - 'Comprehensive Project: A mini-STL Algorithm Library with Concepts'

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
@@ -11,7 +11,7 @@ prerequisites:
 - 'Constraining Templates with Concepts: Subsumption and Overloading'
 - 'Requires Expressions, In Depth: The Four Kinds'
 - 'TMP Core Techniques: The World Before Concepts'
-reading_time_minutes: 16
+reading_time_minutes: 11
 related:
 - 'Concepts: Putting Constraints in the Signature'
 - 'Templates and Exception Safety: move_if_noexcept and Reallocation'

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
@@ -1,0 +1,151 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 'Weld the volume together. A mini-STL algorithm library constrained by C++20 concepts. Implementing transform, accumulate, and find_if with proper constraints, and seeing what concepts buy you in a real generic library: readable signatures and error messages that name the constraint.'
+difficulty: intermediate
+order: 9
+platform: host
+prerequisites:
+- 'Concepts: Putting Constraints in the Signature'
+- 'Constraining Templates with Concepts: Subsumption and Overloading'
+- 'Requires Expressions, In Depth: The Four Kinds'
+- 'TMP Core Techniques: The World Before Concepts'
+reading_time_minutes: 16
+related:
+- 'Concepts: Putting Constraints in the Signature'
+- 'Templates and Exception Safety: move_if_noexcept and Reallocation'
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 泛型
+- concepts
+- 编译期计算
+title: 'Comprehensive Project: A mini-STL Algorithm Library with Concepts'
+---
+# Comprehensive Project: A mini-STL Algorithm Library with Concepts
+
+We've covered a loop of conceptual material in this volume: how to write concepts, the four kinds of requires expressions, the old TMP techniques, compile-time strings, C++26 reflection, instantiation control, exception safety. This piece welds them into something concrete: a mini-STL algorithm library constrained by concepts. We'll implement three classic algorithms, `transform`, `accumulate`, `find_if`, give them proper constraints, and see what concepts actually buy in a real generic library. No suspense: two things, signatures you can read, and error messages that talk like a person.
+
+## The goal: three algorithms, signatures as documentation
+
+First, what we're building. `transform` runs a function over a range and writes the results out. `accumulate` folds the elements of a range together. `find_if` finds the first element that satisfies a predicate. The standard library has all three (`std::ranges::transform` and friends). We're not replacing them. We're putting the volume's tools into one runnable example.
+
+One design principle: **every template parameter is constrained by a concept, and the signature alone tells you what it needs**. Let's walk through each.
+
+## Two custom concepts: name the needs the standard library doesn't cover
+
+The standard `<concepts>` and `<iterator>` provide a batch of ready-made concepts (`input_iterator`, `predicate`, `invocable`, `convertible_to`, and more), and most needs are covered. But two needs have no off-the-shelf concept, so we name them ourselves:
+
+```cpp
+template <typename T, typename U = T>
+concept Addable = requires(T a, U b) {
+    { a + b } -> std::convertible_to<U>;
+};
+
+template <typename T>
+concept Ordered = requires(T a, T b) {
+    { a < b } -> std::convertible_to<bool>;
+};
+```
+
+`Addable<T, U>` asks "can `T` and `U` be added, with a result convertible to `U`." The default `U = T` means `Addable<int>` is "int can add with itself." `Ordered` asks "can it be compared with `<`, result convertible to bool." Once these two names exist, the algorithm signatures have something to write. This step maps to the compound requirement from piece 03: `{ a + b } -> std::convertible_to<U>` both checks that the expression is valid and that the return type satisfies the constraint.
+
+## transform: use ready-made range and iterator concepts
+
+```cpp
+template <std::ranges::input_range R, typename Out, typename F>
+    requires std::output_iterator<Out, std::ranges::range_value_t<R>>
+          && std::invocable<F&, std::ranges::range_reference_t<R>>
+Out transform(R&& r, Out out, F f) {
+    for (auto&& x : r) {
+        *out++ = std::invoke(f, x);
+    }
+    return out;
+}
+```
+
+This signature reads as its own documentation: `R` is an input range, `Out` is an output iterator (writable with `R`'s element type), `F` is callable (accepting a reference to `R`'s element). Three requirements, all in the template parameter list and the requires clause. No `enable_if` nesting anywhere.
+
+One detail from piece 03 is worth rereading here. `std::invocable<F&, std::ranges::range_reference_t<R>>` uses `range_reference_t<R>`, not `range_value_t<R>`. Iterating a range yields **references** to elements, and the function has to accept the reference type to be correct. Getting this type right, before concepts, meant a detour through `decltype` and `std::declval`. Now the standard aliases (`range_value_t`, `range_reference_t`) hand it to you.
+
+## accumulate: the custom Addable takes the stage
+
+```cpp
+template <std::ranges::input_range R, typename T>
+    requires Addable<T, std::ranges::range_value_t<R>>
+T accumulate(R&& r, T init) {
+    for (auto&& x : r) {
+        init = init + x;
+    }
+    return init;
+}
+```
+
+The constraint is `Addable<T, range_value_t<R>>`: the accumulator type `T` must be addable with the range's element type. That's more direct than the standard `std::accumulate`, which is an unconstrained template. The standard one, given a wrong type, sends the error deep into a substitution failure inside `operator+`. Ours says "`Addable` wasn't satisfied." `Addable` also isn't limited to numbers. As long as a type has `operator+` whose result converts back, `std::string` accumulates just fine (we'll see it in the run below).
+
+## find_if: use std::predicate
+
+```cpp
+template <std::ranges::input_range R, typename Pred>
+    requires std::predicate<Pred&, std::ranges::range_reference_t<R>>
+std::ranges::borrowed_iterator_t<R> find_if(R&& r, Pred pred) {
+    for (auto it = std::ranges::begin(r); it != std::ranges::end(r); ++it) {
+        if (std::invoke(pred, *it)) return it;
+    }
+    return std::ranges::end(r);
+}
+```
+
+`std::predicate<Pred&, T>` is stricter than `std::invocable`: not only must it be callable, the return must be convertible to bool. A `find_if` predicate obviously returns bool, so `predicate` fits better than `invocable`. The return type `borrowed_iterator_t<R>` is a ranges detail that handles "does the iterator dangle if a temporary range is passed in." We won't unpack it here.
+
+## Run it
+
+Run all three together, covering numbers, strings, and a predicate:
+
+<OnlineCompilerDemo allow-run
+  title="A concepts-constrained mini-STL: transform / accumulate / find_if"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/mini_stl.cpp"
+  description="transform squares, accumulate sums and concatenates, find_if finds the first even. The same accumulate adds integers and concatenates strings."
+/>
+
+Run it:
+
+```text
+transform squared: 1 4 9 16
+accumulate sum:  10
+accumulate concat:  start:abc
+find_if first even: 2
+```
+
+All four lines match what you'd expect. `transform` squares `{1,2,3,4}` into `{1,4,9,16}`. `accumulate` sums to 10. The third line is the interesting one: `accumulate` concatenates strings into `start:abc`. The same algorithm adds integers and concatenates strings, because `Addable` only asks for `operator+`, not for the type to be numeric. That's the value of generics, and concepts make it both flexible (any Addable type) and safe (non-Addable types don't get in).
+
+## Wrong type, error message that talks
+
+The most convincing thing is how it rejects the wrong type. Define a `NoPlus` with no `operator+`, and call `accumulate` on it:
+
+```cpp
+struct NoPlus {};
+std::vector<NoPlus> v(3);
+my::accumulate(v, NoPlus{});   // Addable constraint not satisfied
+```
+
+```text
+constraints not satisfied
+required for the satisfaction of 'Addable<T, std::ranges::range_value_t<_Range>>'
+    [with T = NoPlus; R = std::vector<NoPlus, ...>&]
+```
+
+Compare that to the `enable_if` hieroglyphics from piece 04. There it was `no type named 'type' in 'std::enable_if<false, void>'`, all about `enable_if`'s internals. Here it says straight that `Addable<NoPlus, ...>` wasn't satisfied, calling out the constraint name and substituting in the concrete type. The reader doesn't need to understand SFINAE. They see "`NoPlus` can't be added." The "save half your hair" promise from piece 01 is delivered, in a real generic library.
+
+## What concepts buy a generic library
+
+Put these three snippets next to an equivalent C++17 `enable_if` version, and the difference is clear. Concepts bring three concrete things.
+
+First, **signatures as documentation**. `requires input_range<R> && output_iterator<Out, ...>` reads like a spec. You don't have to dig into the implementation to see what it assumes about the parameters. Second, **errors name the constraint**. Pass the wrong type and the compiler says "which concept wasn't satisfied," not "enable_if substitution failed." Third, **constraints are reusable and composable**. `Addable` is defined once, and any algorithm that needs "can be added" uses it. Multiple concepts combine with `&&`, and they can participate in overload dispatch through the subsumption rules from piece 02. Together that's the jump from "you can write generic code" to "you can write it comfortably, read it clearly, and survive errors."
+
+## Volume closing
+
+This volume started with concepts, explaining how to write constraints, how they participate in overloading, and the four kinds of requires expressions. Then it stepped back to TMP's old toolkit: the internals of `type_traits`, template recursion, SFINAE, `void_t`, fold expressions, and how to migrate them onto concepts. Compile-time strings and C++20 NTTP class type came next. A look at C++26 static reflection followed. Then back to engineering: template instantiation control, how templates and exceptions tangle, and a mini-STL algorithm library to weld the main line together. Concepts are the spine of this volume, but they aren't all of it. TMP recursion and specialization, fold expressions, conditional `noexcept` are still everyday tools after concepts arrived. Read through this volume and you should be able to write constraints the C++20 way, read the SFINAE and `void_t` in older libraries, and know when to reach for which.

--- a/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/index.md
+++ b/documents/en/vol4-advanced/vol3-metaprogramming-cpp20-23/index.md
@@ -1,28 +1,26 @@
 ---
-title: Metaprogramming Essentials (C++20-23)
-description: 'C++20/23 Metaprogramming: Concepts, requires expressions, core TMP techniques,
-  compile-time strings'
-translation:
-  source: documents/vol4-advanced/vol3-metaprogramming-cpp20-23/index.md
-  source_hash: 995e3937de7e365efe8160cc2c962ff4ef517ddc34cde0bdd9c1d51327c4759b
-  translated_at: '2026-05-26T11:40:11.624150+00:00'
-  engine: anthropic
-  token_count: 90
+title: "Metaprogramming Essentials (C++20-23)"
+description: "How C++20/23 does compile-time computation and type deduction, and how concepts replaced the SFINAE dark arts with readable constraints."
 ---
+
 # Metaprogramming Essentials (C++20-23)
 
-> Status: To be written
+This part picks up where Volume 1's template basics left off. Volume 1 covered the "mechanism": the compilation model of templates, specialization, two-phase lookup. This part covers how to use those mechanisms for **compile-time computation and type deduction**, and how C++20 concepts rewrote the old SFINAE and `enable_if` drudgery into readable constraints.
 
-This section dives deep into modern C++ constraint mechanisms and advanced metaprogramming techniques, covering concepts, requires expressions, core TMP techniques, compile-time strings, reflection fundamentals, instantiation control, and exception safety.
+Three threads run through it: concepts and requires expressions (C++20), classic template metaprogramming (TMP) techniques and their modernization, and compile-time strings plus C++26 reflection.
 
-## Chapter Contents (To be written)
+Runnable examples live in [code/examples/vol4/vol3-metaprogramming-cpp20-23/](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/examples/vol4/vol3-metaprogramming-cpp20-23). Each file compiles with `g++ -std=c++20 xxx.cpp`, except the reflection examples in piece 06 which need Godbolt's clang-p2996 (the local compilers don't support P2996 yet).
 
-1. Concepts in detail
-2. Constraining templates with concepts
-3. Deep dive into requires expressions
-4. Core TMP techniques
-5. Compile-time string processing
-6. Reflection metaprogramming fundamentals
-7. Template instantiation control
-8. Templates and exception safety
-9. Comprehensive project: mini-STL algorithm library
+<ChapterNav variant="sub">
+  <ChapterLink href="01-concepts">Concepts: Putting Constraints in the Signature</ChapterLink>
+  <ChapterLink href="02-constraining-templates">Constraining Templates with Concepts: Subsumption and Overloading</ChapterLink>
+  <ChapterLink href="03-requires-expressions">Requires Expressions, In Depth: The Four Kinds</ChapterLink>
+  <ChapterLink href="04-tmp-core-techniques">TMP Core Techniques: The World Before Concepts</ChapterLink>
+  <ChapterLink href="05-compile-time-strings">Compile-Time Strings: NTTP Class Type and fixed_string</ChapterLink>
+  <ChapterLink href="06-static-reflection-basics">Static Reflection Basics: The Reflection Operator and Splice</ChapterLink>
+  <ChapterLink href="07-template-instantiation-control">Template Instantiation Control: extern template and Compile Time</ChapterLink>
+  <ChapterLink href="08-templates-and-exception-safety">Templates and Exception Safety: move_if_noexcept and Reallocation</ChapterLink>
+  <ChapterLink href="09-mini-stl-with-concepts">Comprehensive Project: A mini-STL Algorithm Library with Concepts</ChapterLink>
+</ChapterNav>
+
+The concepts trio (01-03) is the foundation, covering how to write constraints, how they participate in overloading, and the four kinds of requires expressions with their two traps. Piece 04 steps back to TMP's old toolkit (the internals of `type_traits`, template recursion, SFINAE, `void_t`, fold expressions) and the migration of SFINAE onto concepts. Piece 05 covers compile-time strings (C++20 NTTP class type and `fixed_string`). Piece 06 looks ahead at C++26 static reflection (P2996's reflection operator and splice). Piece 07 covers template instantiation control (`extern template` and compile time). Piece 08 covers templates and exception safety (`move_if_noexcept` and container reallocation). Piece 09 closes with a concepts-constrained mini-STL algorithm library that welds the volume together.

--- a/documents/en/vol4-advanced/vol4-generics-patterns/index.md
+++ b/documents/en/vol4-advanced/vol4-generics-patterns/index.md
@@ -16,8 +16,6 @@ Design patterns represent classic solutions to recurring design problems, distil
 
 Unlike traditional tutorials that follow a "Definition + UML + Example" format, our approach is to **start from the most intuitive, primitive code and step-by-step derive each pattern**. We clarify exactly what problem each pattern solves, why each evolutionary step is insufficient, and how—with C++17/20 features like `std::variant`, concepts, CRTP, and templates—we can achieve safer, zero-overhead versions of these classic patterns.
 
-Key features throughout this volume: every pattern includes "let's verify this" real terminal output (not just theory on paper); common pitfalls are highlighted in `::: warning` blocks; and wherever modern C++ can replace old idioms, we place "Classic vs. Modern" side-by-side for comparison.
-
 The accompanying compilable project is located in the repository at [code/volumn_codes/vol4/design-patterns/](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/volumn_codes/vol4/design-patterns). Each pattern is a separate CMake sub-project. Run `cmake -S . -B build && cmake --build build` to build and run.
 
 ## Creational

--- a/documents/vol2-modern-features/ch00-move-semantics/05-move-in-practice.md
+++ b/documents/vol2-modern-features/ch00-move-semantics/05-move-in-practice.md
@@ -923,13 +923,13 @@ a 重新赋值后: 999
 
 在线运行两个示例，亲手验证这篇的关键结论：
 
-<OnlineCompilerDemo
+<OnlineCompilerDemo allow-run
   title="push_back vs emplace_back：拷贝、移动、原位构造"
   source-path="code/examples/vol2/push_back_emplace.cpp"
   description="追踪 Heavy 对象的构造、拷贝、移动、析构日志，对比 push_back(左值)、push_back(右值)、emplace_back 三种方式的开销。"
 />
 
-<OnlineCompilerDemo
+<OnlineCompilerDemo allow-run
   title="noexcept 对 sort 与 vector 扩容的影响"
   source-path="code/examples/vol2/noexcept_sort_vs_realloc.cpp"
   description="统计拷贝和移动次数：std::sort 不区分 noexcept，但 vector 扩容会通过 move_if_noexcept 在非 noexcept 类型上退回拷贝。"

--- a/documents/vol4-advanced/vol1-basics-cpp11-14/index.md
+++ b/documents/vol4-advanced/vol1-basics-cpp11-14/index.md
@@ -7,8 +7,6 @@ description: "C++ 模板编程的核心基础:从函数模板到 CRTP 的完整�
 
 C++ 模板是泛型编程的核心机制。本部分从「会用模板」推进到「想写库、读得懂 STL 源码」的视角,讲透模板的编译模型、特化与偏特化、非类型参数、两阶段名字查找、隐藏友元、别名模板和 CRTP,最后用一个 `fixed_vector<T, N>` 综合项目把前九篇焊在一起。
 
-每篇都带「上手跑一跑」的真实编译输出,该踩的坑写成 `::: warning` 预警块,关键的编译期行为用汇编佐证。
-
 配套可运行示例在 [code/examples/vol4/vol1-basics-cpp11-14/](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/examples/vol4/vol1-basics-cpp11-14),四个最有复用价值的例子(fixed_vector、CRTP 静态多态、Comparable mixin、手写 type_traits),每个文件 `g++ -std=c++20 xxx.cpp` 直接跑。
 
 <ChapterNav variant="sub">

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/01-concepts.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/01-concepts.md
@@ -86,8 +86,15 @@ T form4(T a, T b) { return a + b; }
 
 跑一下,四种形式各调一次:
 
-```bash
-$ g++ -std=c++20 -Wall -Wextra four_forms.cpp -o four_forms && ./four_forms
+<OnlineCompilerDemo allow-run
+  title="Concept 的四种语法形式"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/concepts_four_forms.cpp"
+  description="把同一个 add 用四种方式约束:模板参数列表、requires 子句、简写 auto、内嵌 requires 表达式。"
+/>
+
+运行结果:
+
+```text
 form1: 8
 form2: 5
 form3: 30
@@ -142,7 +149,6 @@ add_concept.cpp:16:8: error: no matching function for call to 'add(std::string&,
 ```cpp
 #include <concepts>
 #include <iostream>
-#include <string>
 #include <vector>
 
 struct Base {};
@@ -151,27 +157,40 @@ struct Unrelated {};
 
 int main() {
     std::cout << std::boolalpha;
-    std::cout << "same_as<int,int>:           " << std::same_as<int, int> << "\n";
-    std::cout << "same_as<int, const int>:    " << std::same_as<int, const int> << "\n";
-    std::cout << "convertible_to<int,double>: " << std::convertible_to<int, double> << "\n";
-    std::cout << "derived_from<Derived,Base>: " << std::derived_from<Derived, Base> << "\n";
+    std::cout << "same_as<int,int>:             " << std::same_as<int, int> << "\n";
+    std::cout << "same_as<int, const int>:      " << std::same_as<int, const int> << "\n";
+    std::cout << "convertible_to<int,double>:   " << std::convertible_to<int, double> << "\n";
+    std::cout << "convertible_to<double,int>:   " << std::convertible_to<double, int> << "\n";
+    std::cout << "derived_from<Derived,Base>:   " << std::derived_from<Derived, Base> << "\n";
     std::cout << "derived_from<Unrelated,Base>: " << std::derived_from<Unrelated, Base> << "\n";
-    std::cout << "common_with<int,double>:    " << std::common_with<int, double> << "\n";
-    std::cout << "integral<bool>:            " << std::integral<bool> << "\n";
-    std::cout << "floating_point<float>:     " << std::floating_point<float> << "\n";
+    std::cout << "common_with<int,double>:      " << std::common_with<int, double> << "\n";
+    std::cout << "default_initializable<int>:   " << std::default_initializable<int> << "\n";
+    std::cout << "integral<int>:                " << std::integral<int> << "\n";
+    std::cout << "integral<bool>:               " << std::integral<bool> << "\n";
+    std::cout << "floating_point<float>:        " << std::floating_point<float> << "\n";
 }
 ```
 
-```bash
-$ g++ -std=c++20 -Wall -Wextra stdconcepts.cpp -o stdconcepts && ./stdconcepts
-same_as<int,int>:           true
-same_as<int, const int>:    false
-convertible_to<int,double>: true
-derived_from<Derived,Base>: true
+<OnlineCompilerDemo allow-run
+  title="标准库 concepts 常用概念实测"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/stdconcepts_demo.cpp"
+  description="same_as / convertible_to / derived_from / common_with / integral / floating_point 的真实判断。"
+/>
+
+运行结果:
+
+```text
+same_as<int,int>:             true
+same_as<int, const int>:      false
+convertible_to<int,double>:   true
+convertible_to<double,int>:   true
+derived_from<Derived,Base>:   true
 derived_from<Unrelated,Base>: false
-common_with<int,double>:    true
-integral<bool>:            true
-floating_point<float>:     true
+common_with<int,double>:      true
+default_initializable<int>:   true
+integral<int>:                true
+integral<bool>:               true
+floating_point<float>:        true
 ```
 
 这里有个容易踩的点。`same_as<int, const int>` 跑出来是 **false**,而您的直觉可能觉得「不都是 int 嘛」。原因是 `const` 限定让它们成为两个不同的类型,`std::is_same_v<int, const int>` 本来就是 false,`same_as` 建立在它之上,自然也是 false。如果您想判断「剥掉 cv 限定和引用之后是不是同一个类型」,得先用 `std::remove_cvref_t` 把限定擦掉再比。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/02-constraining-templates.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/02-constraining-templates.md
@@ -76,8 +76,15 @@ struct SafeNumber {
 Numeric auto half(Numeric auto x) { return x / 2; }
 ```
 
-```bash
-$ g++ -std=c++20 -Wall -Wextra constraints_everywhere.cpp -o ce && ./ce
+<OnlineCompilerDemo allow-run
+  title="约束可以用在哪:函数/类/成员/auto"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/constraints_everywhere.cpp"
+  description="Numeric 约束加在函数模板、类模板、成员函数、简写 auto 上,四种位置都能编。"
+/>
+
+运行结果:
+
+```text
 square(4) = 16
 square(2.5) = 6.25
 SafeNumber(3) + 4 = 7
@@ -112,8 +119,11 @@ int main() {
 }
 ```
 
-```bash
-$ g++ -std=c++20 -Wall -Wextra subsumption_basic.cpp -o sub1 && ./sub1
+这里贴的是核心部分。完整文件(含下面 conjunction 节要讲的 `Both/C`)见 [subsumption_overloads.cpp](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/examples/vol4/vol3-metaprogramming-cpp20-23/subsumption_overloads.cpp)。
+
+运行结果(animal/dog 部分):
+
+```text
 an animal
 a dog
 ```
@@ -192,6 +202,20 @@ C
 ::: warning 约束不是看名字,是看原子
 subsumption 比较的是规范化后的**原子约束集合**,不是 concept 的名字。`C2 = C1<T>` 不会让 `C2` 比 `C1` 更特定,因为它们的原子约束相同。想让一个重载胜出,得让它的原子约束集合是对方的真超集,最常用的办法就是用 `&&` 再叠一个约束。记住这一条,后面写带约束的重载族时就不会被「明明名字不一样怎么还歧义」绕进去。
 :::
+
+<OnlineCompilerDemo allow-run
+  title="Subsumption 完整演示:animal/dog 与 conjunction 的 C"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/subsumption_overloads.cpp"
+  description="subsumption_overloads.cpp 完整运行:Cat 走宽重载、Pup 走窄重载、Both 同时满足 A/B/C 被选为 C。"
+/>
+
+完整运行结果:
+
+```text
+an animal
+a dog
+C
+```
 
 ## 坑:别把 concept 当 is_same 用
 

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/03-requires-expressions.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/03-requires-expressions.md
@@ -95,10 +95,17 @@ void process(T t) {
 }
 ```
 
-```bash
-$ g++ -std=c++20 -Wall -Wextra four_requirements2.cpp -o fr2 && ./fr2
-has empty()      // std::vector<int> 有 empty()
-no empty()       // int 没有
+<OnlineCompilerDemo allow-run
+  title="Requires 表达式当 bool 用"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/requires_expression.cpp"
+  description="内联 requires 表达式直接塞进 if constexpr,编译期判断类型有没有 empty(),不用先定义 concept。"
+/>
+
+运行结果:
+
+```text
+has empty()
+no empty()
 ```
 
 临时检查一下「这个类型有没有某个操作」,用内联 requires 表达式最省事。但要注意一个取舍:内联表达式没有名字,它不形成可复用的原子约束。上一篇讲 subsumption 时说过,重载分派靠命名的 concept 建立蕴含关系。如果您想让两个重载靠约束分派,得用命名的 concept(`concept C = requires(...){...}`),内联表达式做不到 subsumption。所以「只在某一处用一次」的检查用内联表达式,「要参与重载或反复复用」的要求提成 concept。
@@ -130,8 +137,15 @@ int main() {
 }
 ```
 
-```bash
-$ g++ -std=c++20 -Wall -Wextra unevaluated.cpp -o ue && ./ue
+<OnlineCompilerDemo allow-run
+  title="Requires 表达式不求值,counter 实证"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/unevaluated.cpp"
+  description="requires 里的 increment() 调用只检查合法性不执行,concept 求值后 counter 仍是 0,直到 main 里真正调用。"
+/>
+
+运行结果:
+
+```text
 concept 求值完毕,counter = 0
 [副作用] increment 被调用了
 真正调用后,counter = 1

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/04-tmp-core-techniques.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/04-tmp-core-techniques.md
@@ -1,0 +1,254 @@
+---
+chapter: 13
+cpp_standard:
+- 17
+- 20
+description: concepts 之前的十几年里,泛型库靠 TMP 回答类型问题。讲清 type_traits 的特化内幕、模板递归、SFINAE 与 enable_if、void_t 的 detection idiom、C++17 fold expressions,以及怎么把约束类的 SFINAE 往 concepts 上迁
+difficulty: intermediate
+order: 4
+platform: host
+prerequisites:
+- Concepts:把模板约束写进签名
+- 使用 Concepts 约束模板:subsumption 与重载
+- Requires 表达式深度解析:四种成分
+reading_time_minutes: 17
+related:
+- Requires 表达式深度解析:四种成分
+- 编译期字符串:NTTP class type 与 fixed_string
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板元编程
+- 编译期计算
+- 泛型
+title: TMP 核心技巧:concepts 之前的世界
+---
+# TMP 核心技巧:concepts 之前的世界
+
+前三篇咱们一直在 C++20 concepts 的光照下看「约束」。但 concepts 是 2020 年才进标准的新东西,在那之前的十几年里,泛型库的作者要回答「这个类型合不合格」,靠的是另一套完全不同的机制——模板元编程(Template Metaprogramming,TMP)。这一篇咱们倒回去看看 TMP 的几样看家本事:用特化做编译期问询、用模板递归做编译期循环、用 SFINAE 让不合适的重载优雅退场、用 `void_t` 检测成员是否存在,以及 C++17 的 fold expressions 怎么替掉一大部分模板递归。
+
+这些东西今天看起来啰嗦,但至今没被 concepts 完全取代。您翻标准库源码、翻 Boost、翻 Chromium 的 base,到处都是 SFINAE 和 `void_t`。concepts 接管的是「类型合不合格」这类约束,「在类型上算个数」的活儿还得靠 TMP。这一篇讲的因此是您读和写真实泛型代码绕不开的基本功。
+
+## type_traits 的内幕:特化就是编译期的 if-else
+
+`std::is_pointer_v<int*>` 算出 `true`,`std::is_pointer_v<int>` 算出 `false`。这个编译期的判断是怎么实现的?答案朴素得让人意外,靠的是模板偏特化。咱们自己手写一个 `is_pointer`,结构就和标准库的差不多:
+
+```cpp
+template <typename T>
+struct is_pointer_impl {
+    static constexpr bool value = false;
+};
+
+template <typename T>
+struct is_pointer_impl<T*> {
+    static constexpr bool value = true;
+};
+
+template <typename T>
+constexpr bool is_pointer_v = is_pointer_impl<T>::value;
+```
+
+主模板兜底,给所有类型一个 `false`;偏特化专门匹配 `T*` 这种「指向某个类型的指针」,给 `true`。编译器实例化 `is_pointer_impl<int*>` 的时候,会发现偏特化比主模板更贴,就选偏特化;实例化 `is_pointer_impl<int>` 的时候没有更特化的版本能匹配,只能落回主模板。这就是 TMP 最基本的范式,用特化做编译期的分派,等价于一个在类型上展开的 if-else。
+
+跑一下,和标准库对一遍:
+
+<OnlineCompilerDemo allow-run
+  title="手写 is_pointer,用特化做编译期分派"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/traits_from_scratch.cpp"
+  description="主模板兜底 false,偏特化匹配 T* 给 true,和标准库 std::is_pointer 结果一致。"
+/>
+
+运行结果:
+
+```text
+is_pointer_v<int>:    false
+is_pointer_v<int*>:   true
+is_pointer_v<int**>:  true
+is_pointer_v<double*>:true
+与 std::is_pointer 结果一致
+```
+
+标准库的 `<type_traits>` 里那一两百个 trait(`is_integral`、`is_class`、`remove_const`、`decay`……)底层基本都是这套:主模板 + 一组偏特化覆盖各种情况。`remove_const_t<const int>` 变成 `int`,无非是给 `const T` 写了个偏特化,里头 `using type = T`。一旦您把这个「特化即分派」的模型想明白,再去看 `<type_traits>` 的源码就不会发怵了。
+
+## 模板递归:用实例化做循环
+
+光做类型问询还不够,TMP 还能在编译期算数。做法是把循环展开成一连串模板实例化,靠特化提供终止条件。经典例子是阶乘:
+
+```cpp
+template <unsigned N>
+struct Factorial {
+    static constexpr unsigned value = N * Factorial<N - 1>::value;
+};
+
+template <>
+struct Factorial<0> {
+    static constexpr unsigned value = 1;
+};
+```
+
+`Factorial<5>::value` 的求值过程是编译器在编译期一路实例化下去:`Factorial<5>` 引用 `Factorial<4>::value`,`Factorial<4>` 又引用 `Factorial<3>`,直到撞上 `Factorial<0>` 的全特化,`value` 是 `1`,递归才回溯回来把每一层乘出来。这个展开完全发生在编译期,到运行时 `Factorial<5>::value` 就是个常量 `120`,没有任何函数调用开销。
+
+<OnlineCompilerDemo allow-run
+  title="模板递归算阶乘,特化提供终止条件"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/tmp_factorial.cpp"
+  description="Factorial<N> 递归引用 Factorial<N-1>,直到撞上 Factorial<0> 的全特化,值在编译期算定。"
+/>
+
+运行结果:
+
+```text
+Factorial<5>::value  = 120
+Factorial<10>::value = 3628800
+编译期断言全部通过
+```
+
+`static_assert` 能在编译期断言 `Factorial<10>::value == 3628800`,说明这个值在编译阶段就已经算定了。这种「模板递归 + 特化终止」是 TMP 的经典循环模式,曾经被用来做编译期排序、编译期字符串处理、typelist 操作各种重活。它的代价也实在:实例化层数深、编译慢,报错还特别难读。这正是后来 fold expressions 被造出来的直接动机。
+
+## SFINAE:让不合适的重载优雅退场
+
+traits 解决了「这个类型是什么」,但泛型库还要解决另一个问题:我有两个重载,一个给整数、一个给浮点,怎么让编译器在传错类型时**不报错、而是悄悄跳过不合适的那个**?答案是一组叫 SFINAE 的规则,全称 Substitution Failure Is Not An Error,「替换失败不是错误」。
+
+意思是:编译器在把模板参数往签名里替换的时候,如果某一步替换出了问题(比如生成了 `int::value_type` 这种不存在的类型),它不会立刻报错,而是把这个重载当作「替换失败」默默踢出候选集,继续试别的。`std::enable_if` 就是利用这条规则的老牌工具,它把约束藏进一个默认模板参数里:
+
+```cpp
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+T add_old(T a, T b) {
+    return a + b;
+}
+```
+
+`std::enable_if_t<条件>` 只有在条件为 `true` 时才有内嵌的 `type`;条件为 `false` 时它是个空壳,替换进去会让默认参数的类型推导失败,这个重载就被 SFINAE 踢掉。结果是:传 `int` 能匹配,传 `std::string` 时这个重载压根不在候选里。
+
+SFINAE 能跑,但它的报错信息是出了名的折磨人。咱们故意用 `std::string` 去调上面那个 `add_old`,看 GCC 16.1.1 吐什么(节选):
+
+```text
+error: no matching function for call to 'add_old(std::string, std::string)'
+  candidate: 'template<class T, class> T add_old(T, T)'
+    template argument deduction/substitution failed:
+    error: no type named 'type' in 'struct std::enable_if<false, void>'
+```
+
+报错的核心是 `no type named 'type' in 'std::enable_if<false, void>'`。它讲的是 `enable_if` 的内部机制——条件为假所以没有 `type` 这个成员——偏偏不提您真正关心的那件事。您得先懂 SFINAE,再倒推出「哦,是因为 string 不是整数」。这正是前三篇里 concepts 反复对比的那条老路子,这里咱们是从机制这一侧看清它为什么难读。
+
+## void_t 与 detection idiom:C++17 的高光
+
+SFINAE 最优雅的用法,是 2014 年前后由 Walter Brown 提出的一套叫 detection idiom(检测惯用法)的模式。它的核心是一个看起来什么都没干的工具:`std::void_t`。
+
+```cpp
+template <typename...>
+using void_t = void;
+```
+
+`void_t` 把任意类型映射成 `void`。它本身毫无逻辑,但配上偏特化,就能做一件 SFINAE 时代最难做的事:**优雅地检测一个类型有没有某个成员**。咱们检测「T 有没有 `value_type` 这个内嵌类型」:
+
+```cpp
+template <typename T, typename = void>
+struct has_value_type : std::false_type {};
+
+template <typename T>
+struct has_value_type<T, std::void_t<typename T::value_type>> : std::true_type {};
+```
+
+主模板默认继承 `false_type`;偏特化的第二个模板参数是 `std::void_t<typename T::value_type>`。关键在编译器怎么挑这两个版本。实例化 `has_value_type<std::vector<int>>` 时,编译器会先试更特化的偏特化,把 `T` 替换成 `std::vector<int>`,然后试图求值 `std::void_t<std::vector<int>::value_type>`——`vector<int>` 确实有 `value_type`,替换成功,`void_t` 把它变成 `void`,偏特化的第二个参数落定为 `void`,和主模板的默认 `void` 对上了,偏特化被选中,结果是 `true_type`。反过来实例化 `has_value_type<int>` 时,`int::value_type` 不存在,替换失败——按 SFINAE 规则,失败不是错误,偏特化被悄悄踢掉,编译器退回主模板,结果是 `false_type`。
+
+跑一下:
+
+<OnlineCompilerDemo allow-run
+  title="void_t 的 detection idiom,检测内嵌类型是否存在"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/void_t_detection.cpp"
+  description="主模板继承 false_type,偏特化靠 void_t 在替换成功时被选中,从而优雅地返回 true 或 false。"
+/>
+
+运行结果:
+
+```text
+has_value_type_v<std::vector<int>>: true
+has_value_type_v<std::string>:      true
+has_value_type_v<int>:              false
+```
+
+`void_t` 把过去又脏又长的 SFINAE 检测代码收成两行偏特化,这是它在 C++17 被正式收进标准的原因。但有个事实得说清楚。
+
+::: warning 进了标准的只有 void_t,不是整套 detection idiom
+Walter Brown 围绕 detection idiom 写过三篇提案(N3911 → N4436 → N4502),最后一篇 N4502 提议把 `std::is_detected`、`std::detected_t` 这一套现成的检测工具收进标准库。但这套库工具**最终没被投票通过**,进 C++17 的只有 `void_t` 这一个原子零件。所以您在标准库里找不到 `std::is_detected`,要用 detection idiom 只能照着上面那两行偏特化自己手写,或者借助 Boost 等第三方库。concepts 出来之后,「检测某个操作存不存在」的需求大多能更直接地写成 `requires(T t){ t.foo(); }`,新代码里的 detection idiom 在减少,但读老库时它仍然到处都是。
+:::
+
+## fold expressions:干掉递归样板
+
+模板递归能算阶乘,但遇到「对任意个参数求和」这种 variadic 任务,递归写法得给一个主模板、一个递归分支、再加一个终止特化,样板很重。C++17 的 fold expressions 把这块直接省了。对照下面两段:
+
+```cpp
+// 老办法:递归 + 终止
+template <typename T>
+constexpr T sum_rec(T first) { return first; }
+
+template <typename T, typename... Rest>
+constexpr T sum_rec(T first, Rest... rest) {
+    return first + sum_rec(rest...);
+}
+
+// C++17:一个 fold 表达式收掉
+template <typename... Ts>
+constexpr auto sum_fold(Ts... ts) {
+    return (ts + ...);  // 一元右折叠
+}
+```
+
+`(ts + ...)` 把参数包里的所有东西用 `+` 折叠起来。跑一下,两种写法结果一致:
+
+<OnlineCompilerDemo allow-run
+  title="variadic 递归 vs C++17 fold expression"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/fold_vs_recursion.cpp"
+  description="老办法要主模板、递归分支、终止特化三段,C++17 一个 (ts + ...) 折叠就收掉了。"
+/>
+
+运行结果:
+
+```text
+sum_rec(1,2,3,4):  10
+sum_fold(1,2,3,4): 10
+逗号折叠展开: 1 2.5 hi
+```
+
+最后一行那个「逗号折叠展开」是 fold 的另一个常见用法:用逗号运算符把一包操作并起来,`(printer(1), printer(2.5), printer("hi"))` 一行就能展开任意个调用。这在 variadic 场景里几乎替代了过去的递归展开。
+
+fold 一共有四种形式,记一张表就够:
+
+| 形式 | 写法 | 含义(包为 a, b, c,初值 e) |
+|---|---|---|
+| 一元右折叠 | `(pack op ...)` | `(a op (b op c))` |
+| 一元左折叠 | `(... op pack)` | `((a op b) op c)` |
+| 二元右折叠 | `(pack op ... op e)` | `(a op (b op (c op e)))` |
+| 二元左折叠 | `(e op ... op pack)` | `(((e op a) op b) op c)` |
+
+二元形式带个初值 `e`,主要是为了解决空包的问题。一元 fold 对空参数包是 ill-formed,`(ts + ...)` 在没有参数时会编译失败,因为「什么都没有」没法 `+`。但 `&&`、`||` 和逗号这三种运算符的一元 fold 对空包有规定的默认值(`&&` 是 `true`、`||` 是 `false`、逗号是 `void()`),所以 `(... && bs)` 即便 `bs` 为空也能编过。这点在写「一堆约束全部满足」时特别有用,后面讲综合项目还会再用到。
+
+## SFINAE 往 concepts 迁移:同一需求的新旧写法
+
+走到这里,咱们可以把这一篇的东西和前三篇焊一下。同样是「`add` 只接受整数」这个需求,SFINAE 老办法和 concept 新办法放在一起:
+
+```cpp
+// SFINAE(C++11 起):约束藏在默认模板参数里
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+T add_old(T a, T b) { return a + b; }
+
+// concept(C++20):约束写在签名里
+template <typename T>
+    requires std::integral<T>
+T add_new(T a, T b) { return a + b; }
+```
+
+用 `std::string` 去调 concept 版,报错直接点名约束:
+
+```text
+error: no matching function for call to 'add_new(std::string, std::string)'
+  constraints not satisfied
+  required for the satisfaction of 'integral<T>' [with T = std::__cxx11::basic_string<char>]
+```
+
+对比前面 SFINAE 版那个 `no type named 'type' in 'std::enable_if<false, void>'`,差别一目了然:concept 版说人话,直接告诉您 `integral<T>` 没满足,还把具体类型代进去。`enable_if` 版讲的是它自己的内部机制,您得自己翻译回「到底哪条没满足」。
+
+那是不是所有 SFINAE 都该迁成 concepts?大体上,凡是用来「约束模板参数合不合格」的 SFINAE,今天都该优先用 concept,可读性和报错质量是质变。detection idiom 那种「检测某个成员或操作存不存在」的需求,concepts 用 requires 表达式也能写得相当干净(`requires(T t){ t.foo(); }`),新代码同样推荐迁。真正不必迁的,是把 SFINAE 当「类型计算零件」用的场景——比如根据某个条件从两个类型里挑一个,那本来就该用 `std::conditional_t`,跟约束不是一回事。
+
+concepts 接管了 SFINAE 最难读的那部分,没接管 TMP 的全部:模板特化做类型问询、fold expressions 做编译期折叠,这俩仍然是写泛型代码的日常工具。下一篇咱们把 TMP 往一个具体方向推——编译期字符串处理,看看 C++20 的 NTTP class type 怎么让「把字符串当模板参数」这件过去极痛苦的事变得顺手。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
@@ -9,7 +9,7 @@ platform: host
 prerequisites:
 - TMP 核心技巧:concepts 之前的世界
 - Concepts:把模板约束写进签名
-reading_time_minutes: 14
+reading_time_minutes: 12
 related:
 - TMP 核心技巧:concepts 之前的世界
 - 静态反射基础:反射运算符与 splice 重组

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/05-compile-time-strings.md
@@ -1,0 +1,184 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 把字符串当模板参数,在 C++17 之前难到几乎没人做。讲清 const char* 作 NTTP 的坑、C++20 P0732 的 structural type、fixed_string 惯法,以及编译期哈希这条不碰 NTTP 的备选路子
+difficulty: intermediate
+order: 5
+platform: host
+prerequisites:
+- TMP 核心技巧:concepts 之前的世界
+- Concepts:把模板约束写进签名
+reading_time_minutes: 14
+related:
+- TMP 核心技巧:concepts 之前的世界
+- 静态反射基础:反射运算符与 splice 重组
+tags:
+- host
+- cpp-modern
+- intermediate
+- 编译期计算
+- 模板元编程
+- 类型安全
+title: 编译期字符串:NTTP class type 与 fixed_string
+---
+# 编译期字符串:NTTP class type 与 fixed_string
+
+上一篇结尾留了个话头:把字符串当模板参数。这件事听着简单,`template <"hello">` 嘛,但在 C++17 及以前它难到几乎没人愿意做。C++20 的 P0732 提案把这扇门彻底推开,让 class type 能当非类型模板参数(NTTP)用,`fixed_string` 这个经典惯用法就是直接的受益者。这一篇咱们从「为什么以前难」讲到「现在怎么顺手」,顺带说清 structural type 这个新概念到底在约束什么。
+
+## 先说麻烦:C++17 之前 const char* 作 NTTP 的难处
+
+在 C++20 之前,NTTP 只能是整数、枚举、指针、引用这几类,字符串想挤进来只能走 `const char*`。但 `const char*` 作模板参数天生不好用,先看最致命的一刀:字符串字面量**根本不能直接写进模板参数列表**。
+
+```cpp
+template <const char* Name>
+struct Bad {};
+Bad<"hello"> b;   // 字面量作 NTTP,编译失败
+```
+
+```text
+error: '"hello"' is not a valid template argument for type 'const char*'
+       because string literals can never be used in this context
+```
+
+GCC 的原话点得很透,`string literals can never be used in this context`。原因是模板参数要求有链接性(linkage),好让两个翻译单元里同一个模板实例能合并;字符串字面量没有链接性,编译器直接拒收。要让 `const char*` 作 NTTP,您得先把字符串存进一个有外部链接的 `constexpr` 变量里:
+
+```cpp
+constexpr const char kRed[] = "red";   // 有 linkage 的对象
+template <const char* Name>
+struct Tagged { static constexpr const char* name = Name; };
+
+Tagged<kRed> t;   // 这次能编过
+```
+
+能编是能编,但这又引出第二层麻烦:`Tagged<kRed>` 里的参数是 `kRed` 这个**对象的地址**,不是 `"red"` 这串字符的内容。两个翻译单元里如果各定义了一个 `kRed`,它们地址不同,`Tagged<kRed>` 会实例化出两个不同类型。这跟模板「相同参数等于相同类型」的直觉是冲突的。再叠加一层维护成本:每个想用作模板参数的字符串都得先在外面声明一个变量,代码里到处是这种为编译器服务的样板变量。这几条加起来,就是 C++20 之前「字符串当模板参数」基本没人用的原因。
+
+## C++20 的解药:P0732 与 structural type
+
+P0732(Louis Dionne 提出,进 C++20)给了一条新路:让 class type 也能作 NTTP。但有个前提,这个类得是所谓的 **structural type**(结构化类型)。structural 的要求概括成两句:它得是个 literal class type(能在编译期完成构造和析构),而且**所有基类和所有非静态数据成员都必须是 public**。后一条是写代码时最容易踩的线,后面会专门演示。它的本意是让编译器能「按数据成员的值」判断两个模板参数是否等价,而不用去调用用户写的 `operator==`——在模板等价性这种编译期机制里调用户代码,会惹出一堆麻烦。
+
+`fixed_string` 就是顺着这条规则设计出来的:把一串字符包进一个只有 public `char` 数组成员的结构体,它就满足 structural,能作 NTTP 了。下面是一个最小可用的实现:
+
+```cpp
+template <std::size_t N>
+struct FixedString {
+    char value[N] = {};
+
+    // 字面量 "abc" 的类型是 const char[4](含 \0),正好匹配 const char(&)[N]
+    constexpr FixedString(const char (&str)[N]) {
+        for (std::size_t i = 0; i < N; ++i) value[i] = str[i];
+    }
+
+    constexpr bool operator==(const FixedString& other) const {
+        for (std::size_t i = 0; i < N; ++i) {
+            if (value[i] != other.value[i]) return false;
+        }
+        return true;
+    }
+
+    constexpr const char* c_str() const { return value; }
+};
+
+// CTAD 推导指引:让字面量 "hello" 推导出 FixedString<6>(6 含末尾 \0)
+template <std::size_t N>
+FixedString(const char (&)[N]) -> FixedString<N>;
+```
+
+这里有个细节值得停下来看清。`"hello"` 这种字符串字面量,类型是 `const char[6]`,5 个字符加一个结尾 `\0`。所以 CTAD 推导出的 `N` 是 6,`value[6]` 里正好存得下完整字符串和 `\0`。构造函数收的是 `const char(&str)[N]`(数组的引用),这样 `N` 能从字面量的大小推出来,不用手写。
+
+::: warning operator== 不参与模板等价性判断
+咱们给 `FixedString` 写的 `operator==`,只在「运行时比较两个对象」或 `if constexpr` 手动比较时被调用,**和模板参数的等价性判断毫无关系**。编译器判断 `Named<"abc">` 和另一个 `Named<"abc">` 是不是同一类型,依据的是 structural 规则,逐字节比 `value` 数组的值,不调用任何用户代码。换句话说,您把 `operator==` 整个删掉,`Named<"abc">` 和 `Named<"abc">` 仍然是同一类型,`Named<"abc">` 和 `Named<"abd">` 仍然是两个不同类型。想偏了这一点,读别人用 NTTP class type 的代码会处处拧巴。
+:::
+
+## fixed_string 实战:字符串当模板参数
+
+设计好了,就能把 `FixedString` 直接塞进 `template <...>` 里:
+
+```cpp
+template <FixedString S>
+struct Named {
+    static constexpr auto name = S;
+};
+
+template <FixedString S>
+void greet() {
+    std::cout << "hello, " << S.c_str() << "\n";
+}
+```
+
+跑一下:
+
+<OnlineCompilerDemo allow-run
+  title="fixed_string 当 NTTP,字符串编进类型"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/nttp_fixed_string.cpp"
+  description="FixedString 是 structural 类型,能直接塞进 template 参数,字符串由此编进类型本身。"
+/>
+
+运行结果:
+
+```text
+world
+hello, templates
+编译期字符串比较断言通过
+```
+
+`Named<"world">{}` 实例化出一个类型,它的 `name` 成员在编译期就存着 `"world"`;`greet<"templates">()` 同理,字符串 `"templates"` 被编进了类型本身。这件事在 C++17 里几乎做不到,现在一行模板参数就解决了。
+
+再看编译期的字符串比较。`FixedString{"abc"} == FixedString{"abc"}` 在 `static_assert` 里成立,说明比较完全在编译期完成,结果是个常量布尔值。这种能力在「用字符串做编译期分派」的场景里很实在,比如根据一个配置字符串选不同的实现,过去得用枚举绕一圈,现在直接拿字符串字面量说话。
+
+## structural 的限制:为什么不能随便拿个类当 NTTP
+
+P0732 开了门,但只开了 structural 类这扇。咱们试一个故意的反例,把一个有 private 数据成员的类塞进 NTTP:
+
+```cpp
+class Secret {
+    int x;   // private(默认 class 成员是 private)
+public:
+    constexpr Secret(int v) : x(v) {}
+};
+
+template <Secret S>
+struct Bad {};
+Bad<Secret{1}> bad;
+```
+
+```text
+error: 'Secret' is not a valid type for a template non-type parameter
+       because it is not structural
+note: 'Secret::x' is not public
+```
+
+报错把规则说得很直白:`not structural`,原因是 `Secret::x` 不是 public。编译器要能「逐成员看值」来判断两个 NTTP 是否等价,成员如果是 private 的,编译器没法这么直接地访问它们,还会牵涉访问权限的语义,索性一刀切要求全 public。所以您想把一个自定义类作 NTTP,第一步就是检查它的数据成员是不是都暴露在外。带 `std::string` 成员的类也别指望:`std::string` 自己有 private 数据,不满足 structural,连带整个类也用不了。
+
+## 编译期哈希:不一定非得 NTTP
+
+讲到这里要补一句,并不是所有「编译期处理字符串」的需求都需要把字符串编进类型。很多场景用一个 `constexpr` 函数就够,比如编译期算个字符串哈希:
+
+```cpp
+constexpr std::uint64_t fnv1a_64(std::string_view s) {
+    std::uint64_t hash = 14695981039346656037ULL;  // FNV offset basis
+    for (char c : s) {
+        hash ^= static_cast<std::uint64_t>(static_cast<unsigned char>(c));
+        hash *= 1099511628211ULL;  // FNV prime
+    }
+    return hash;
+}
+```
+
+<OnlineCompilerDemo allow-run
+  title="编译期 FNV-1a 字符串哈希"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/compile_time_hash.cpp"
+  description="纯 constexpr 函数,不碰 NTTP,哈希值在编译期算定,可塞进 static_assert。"
+/>
+
+运行结果:
+
+```text
+fnv1a_64("hello") = 11831194018420276491
+fnv1a_64("world") = 5717881983045765875
+编译期哈希断言通过
+```
+
+`fnv1a_64("hello")` 在编译期就算定,可以塞进 `static_assert`、可以当 `switch` 的 `case`(哈希值是常量)、可以做编译期的字符串匹配。这套思路不碰 NTTP,通用性反而更好,`std::string_view` 能接任何字符串来源。所以一个朴素的决策:您需要把字符串编进类型、参与重载或当类型标签时,上 `fixed_string` NTTP;只是想在编译期对一串字符算个结果时,`constexpr` 函数就够,别动用 NTTP。
+
+下一篇咱们往 C++26 看一眼:静态反射(P2996)要让「枚举转字符串、按名字查类型」这类过去得靠 `fixed_string` 加一堆模板苦活才能办的事,变成语言内建的能力。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
@@ -9,7 +9,7 @@ platform: host
 prerequisites:
 - 编译期字符串:NTTP class type 与 fixed_string
 - TMP 核心技巧:concepts 之前的世界
-reading_time_minutes: 15
+reading_time_minutes: 11
 related:
 - 编译期字符串:NTTP class type 与 fixed_string
 - 模板实例化控制:extern template 与编译时间

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/06-static-reflection-basics.md
@@ -1,0 +1,151 @@
+---
+chapter: 13
+cpp_standard:
+- 26
+description: C++26 的 P2996 静态反射让编译期自省成为语言内建能力。讲清反射运算符、splice 重组、identifier_of 与 members_of、template for 遍历,以及枚举转字符串这个杀手级用例。含 Godbolt clang-p2996 实跑输出与本机不支持的诚实交代
+difficulty: advanced
+order: 6
+platform: host
+prerequisites:
+- 编译期字符串:NTTP class type 与 fixed_string
+- TMP 核心技巧:concepts 之前的世界
+reading_time_minutes: 15
+related:
+- 编译期字符串:NTTP class type 与 fixed_string
+- 模板实例化控制:extern template 与编译时间
+tags:
+- host
+- cpp-modern
+- advanced
+- 编译期计算
+- 模板元编程
+- 类型安全
+title: 静态反射基础:反射运算符与 splice 重组
+---
+# 静态反射基础:反射运算符与 splice 重组
+
+上一篇讲编译期字符串时提了一句:C++26 的反射要让「枚举转字符串」这类苦活变成语言内建的能力。这一篇就来兑现这个话头。反射(reflection)指的是程序在编译期「自省」自身结构的能力,某个类有哪些成员、某个枚举有哪些值、某个函数签名长什么样。C++ 等这项能力等了二十多年,直到 P2996 提案在 2025 年 6 月的 WG21 Sofia 会议上投票进入 C++26 工作草案。这一篇讲清反射运算符、splice、几个核心 API,以及两个最直观的用例:遍历 struct 成员、枚举转字符串。
+
+::: warning 这是 C++26,本机主流编译器还跑不了
+P2996 虽然进了 C++26 草案,但实现现状很初期。截至 2026 年 7 月,GCC 和 MSVC 都还没 shipping,能跑的只有 Bloomberg 开源的 clang-p2996 实验分支和 EDG 的预览实现。本机的 GCC 16.1.1 和 clang 22.1.8 都不支持,实测 GCC 即便带 `-freflection` 标志、有空的 `<meta>` 头,见到 `^^Point` 还是会报 `expected primary-expression before '^'`;clang 则根本不认 `-freflection-latest` 这个参数。所以这一篇里所有反射代码的运行输出,都是在 Godbolt 的 `clang_bb_p2996`(Bloomberg 分支 trunk-20260701)上实跑出来的,编译参数 `-std=c++2c -freflection-latest`。您手头要验证,也请去 Godbolt 选这个编译器。
+:::
+
+## 反射运算符 ^^ 和 splice [: :]
+
+P2996 的核心是两个新语法。第一个是反射运算符 `^^`,它作用在一个类型或值上,产出一个叫 `std::meta::info` 的编译期值,编译器拿着它就能去查这个东西的结构。
+
+```cpp
+#include <meta>
+
+struct Point { int x; int y; };
+
+constexpr auto refl = ^^Point;   // refl 是 std::meta::info,指向 Point 这个类型
+```
+
+`^^Point` 算出来是个编译期的 `info` 值,您可以把它当成「关于 `Point` 类型的元信息」。拿到这个 `info`,后续才能去问「你叫什么名字」「你有哪些成员」。
+
+第二个语法是 splice,写法 `[: refl :]`,它把一个 `info` 重新粘回成原本的类型或值。`^^` 把类型变成 `info`,`[: :]` 把 `info` 变回类型,两者互为逆操作。下面讲枚举的例子会看到 `[:enumerator:]` 把一个枚举值的 `info` 粘回成枚举值本身,用来做比较。
+
+## 核心 API:identifier_of、members_of、access_context
+
+拿到 `info` 之后,P2996 在 `std::meta` 命名空间下提供了一组查询函数。这篇用到的几个:
+
+- `identifier_of(info)` 返回实体名字的 `string_view`(R13 之前叫 `name_of`,后来改名)。
+- `nonstatic_data_members_of(type_info, access_context)` 返回一个 `vector<info>`,装着这个类型的所有非静态数据成员。
+- `enumerators_of(enum_info)` 返回枚举的所有枚举值。
+
+`access_context::current()` 这个参数是 P2996R10 之后加的,用来告诉反射「以当前的访问权限去查成员」,毕竟私有成员不是谁都能看见的。每次调用查成员的函数都得把它传进去,啰嗦但是必要。
+
+还有一个绕不开的零件叫 `define_static_array`。P2996 的查询函数返回的是 `constexpr std::vector`,而 `vector` 的内存在堆上,模板里「堆指针」没法当作编译期常量。`define_static_array` 把 vector 的内容物化到一块静态存储里,返回一个能在编译期遍历的 span。听起来绕,但只要您想用 `template for` 遍历查询结果,就得套这一层。
+
+## template for:编译期遍历反射结果
+
+反射返回的东西数量是编译期已知的(一个 struct 的成员数在编译期就定了),但传统 `for` 没法遍历「类型」。P1306 的 expansion statement(`template for`)就是为这个造的,它能对一组编译期已知的值逐个展开,每次迭代的量都是真正的编译期常量,能在类型位置用。
+
+```cpp
+template for (constexpr auto member : members) {
+    std::cout << "  " << std::meta::identifier_of(member) << "\n";
+}
+```
+
+注意是 `template for` 不是 `for`,而且循环变量声明成 `constexpr auto`。这趟循环在编译期完全展开,等价于把每个成员的 `cout` 语句手写一遍。
+
+## 实战一:遍历 struct 的成员
+
+把上面的零件拼起来,就能写出反射版「打印一个 struct 的所有成员名」。完整代码:
+
+```cpp
+#include <meta>
+#include <iostream>
+
+struct Point {
+    int x;
+    int y;
+};
+
+int main() {
+    using namespace std::meta;
+    constexpr auto refl = ^^Point;
+    constexpr auto ctx = access_context::current();
+    constexpr auto members = define_static_array(nonstatic_data_members_of(refl, ctx));
+
+    std::cout << identifier_of(refl) << "\n";
+    template for (constexpr auto member : members) {
+        std::cout << "  " << identifier_of(member) << "\n";
+    }
+}
+```
+
+在 Godbolt 的 clang_bb_p2996 上跑(本机跑不了,原因见开头警告):
+
+```text
+Point
+  x
+  y
+```
+
+这段代码没有任何硬编码的字符串。`Point` 这个名字、`x` 和 `y` 这两个成员名,全是编译器从类型本身查出来的。给 `struct` 加一个字段、改个名,输出的内容自动跟着变,代码一行都不用改。这就是反射的价值,它消除了「类型定义」和「处理类型的代码」之间那道手动同步的缝。
+
+## 实战二:枚举转字符串
+
+反射最出圈的用例,是把枚举值转成它的名字。在反射之前,这件事要么手写一个 `switch` 把每个枚举值映射到字符串(C++ 代码库里遍地都是这种样板),要么靠 magic_enum 这种第三方库用 `__PRETTY_FUNCTION__` 解析偷偷实现。反射让它变成几行直给的代码:
+
+```cpp
+#include <meta>
+#include <iostream>
+#include <string_view>
+
+enum class Color { Red, Green, Blue };
+
+template <typename E>
+constexpr std::string_view enum_to_string(E value) {
+    using namespace std::meta;
+    constexpr auto enumerators = define_static_array(enumerators_of(^^E));
+    template for (constexpr auto enumerator : enumerators) {
+        if (value == [:enumerator:]) {
+            return identifier_of(enumerator);
+        }
+    }
+    return "<unknown>";
+}
+
+int main() {
+    std::cout << enum_to_string(Color::Red) << "\n";
+    std::cout << enum_to_string(Color::Green) << "\n";
+    std::cout << enum_to_string(Color::Blue) << "\n";
+}
+```
+
+```text
+Red
+Green
+Blue
+```
+
+这段值得拆一下。`enumerators_of(^^E)` 拿到枚举 `E` 所有枚举值的 `info` 列表;`template for` 逐个看,`[:enumerator:]` 把当前这个 `info` splice 回成枚举值本身,再和传进来的 `value` 比;匹配上的那个,用 `identifier_of` 取名字返回。整个过程在编译期展开,运行时只剩一串比较,没有字符串解析,也没有查表开销。
+
+这个模板对任何枚举都能用,您新加一个枚举值,`enum_to_string` 自动支持,不用再去补 switch。对照上一篇里咱们为了把字符串编进类型费的那番周折(fixed_string、structural、CTAD),反射让「名字」从一种要费力气搬运的东西,变回编译器本来就掌握的信息,您只是开口去问。
+
+## 还要再等等
+
+P2996 给的能力远不止这两样。按名字查类型、给类型加注解(annotation)、自动生成序列化代码、struct 到 struct 的字段映射,这些过去要靠重型代码生成器或一摞宏的活,反射都能在语言内干掉。但前提是编译器得跟上。这一篇用的 Bloomberg clang-p2996 是「高度实验性」的分支,README 里明说不要用于任何要上生产的产物。在 GCC 和 MSVC 真正 ship 之前,反射主要是「能看到未来」的状态,值得学,因为 API 设计已经稳定(R13 投票通过),等编译器到了就能直接用;但不值得现在就往生产代码里塞。下一篇咱们回到今天就能用的东西,模板实例化怎么控制,编译时间怎么治。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
@@ -1,0 +1,151 @@
+---
+chapter: 13
+cpp_standard:
+- 11
+- 14
+- 17
+description: 模板默认隐式实例化,每个翻译单元各自生成一份同样的代码。讲清显式实例化定义、extern template 声明怎么把实例化集中起来,并诚实评估它对编译时间的真实收益(小项目测不出来,大项目累积才有)
+difficulty: intermediate
+order: 7
+platform: host
+prerequisites:
+- TMP 核心技巧:concepts 之前的世界
+- Concepts:把模板约束写进签名
+reading_time_minutes: 14
+related:
+- 静态反射基础:反射运算符与 splice 重组
+- 模板与异常安全:move_if_noexcept 与扩容
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 编译期计算
+- 工具链
+title: 模板实例化控制:extern template 与编译时间
+---
+# 模板实例化控制:extern template 与编译时间
+
+上一篇结尾说,这一篇回到今天就能用的东西。模板给 C++ 带来了零成本抽象,但也带来一个不那么光鲜的副作用:编译时间。一个模板如果在十几个翻译单元里被用同样的类型参数用到,编译器可能老老实实地在这十几个单元里各实例化一遍。C++11 给了一个能管这件事的工具——`extern template`。这一篇讲清模板实例化的两种控制手段(显式实例化定义、extern template 声明),并且诚实评估它们对编译时间到底有多大帮助。
+
+## 隐式实例化:用到才生成,每个翻译单元各生成一份
+
+模板默认走的是**隐式实例化**:您在某处用了 `Heavy<int>`,编译器就在那个翻译单元里把 `Heavy<int>` 用到的成员现场生成出来。这个机制是「按需」的,用不到的成员不生成,挺好。问题在于它是**每个翻译单元各自一遍**的。
+
+设想一个项目里有 `use_a.cpp` 和 `use_b.cpp`,两处都用了 `Heavy<int>`。编译 `use_a.cpp` 时,编译器实例化一份 `Heavy<int>` 的代码塞进 `use_a.o`;编译 `use_b.cpp` 时,又实例化一份塞进 `use_b.o`。链接的时候,链接器看到两个 `.o` 里都有 `Heavy<int>::compute` 的定义,靠 ODR(单一定义规则)和模板的「弱符号」把它们合并成一份。最后运行时只有一份代码,没问题,但**编译阶段的工作做了两遍**。这就是 extern template 想治的那个症结。
+
+## 显式实例化定义:把实例化集中到一个地方
+
+要管住这件事,得先用上**显式实例化定义**(explicit instantiation definition)。语法是 `template` 开头,跟一个具体的模板实例:
+
+```cpp
+#include "heavy_template.h"
+
+template struct Heavy<int>;   // 在这个翻译单元里实例化 Heavy<int> 的全部成员
+```
+
+这一行的意思是:「请在这个 `.cpp` 里,把 `Heavy<int>` 的所有成员函数都老老实实实例化出来」。它通常单独放在一个叫 `explicit_inst.cpp` 之类的文件里,专门承担「集中实例化」的职责。
+
+## extern template:告诉其他翻译单元「别再生成」
+
+光有集中实例化还不够,别的翻译单元不知道这回事,还是会自己隐式实例化一份。所以要配上**显式实例化声明**,也就是 `extern template`:
+
+```cpp
+#include "heavy_template.h"
+
+extern template struct Heavy<int>;   // Heavy<int> 别处已经实例化,这里别再生成
+```
+
+这一行告诉编译器:「`Heavy<int>` 在别的翻译单元里已经实例化好了,你在这里别再生成代码,只管用」。于是这个翻译单元省掉了实例化的活,链接的时候去 `explicit_inst.o` 里找定义就行。
+
+两者配套,就把「每个 TU 各实例化一遍」收敛成了「只在一个 TU 实例化,其他 TU 直接引用」。下面咱们实测验证这套机制。
+
+## 实测:机制怎么跑起来
+
+一套最小的多文件工程。`heavy_template.h` 定义模板,`use_a.cpp` 走老办法隐式实例化,`use_b.cpp` 用 extern template,`explicit_inst.cpp` 提供显式实例化定义,`main.cpp` 串起来:
+
+```cpp
+// heavy_template.h
+#pragma once
+template <typename T>
+struct Heavy {
+    T value;
+    explicit Heavy(T v) : value(v) {}
+    T compute(T x) const {
+        T acc = value;
+        for (int i = 0; i < 10; ++i) acc = acc * x + value;
+        return acc;
+    }
+};
+```
+
+```cpp
+// use_b.cpp —— extern template 抑制实例化
+#include "heavy_template.h"
+#include <iostream>
+extern template struct Heavy<int>;   // 别处已实例化,这里别再生成
+void use_b() {
+    Heavy<int> h{99};
+    std::cout << "use_b: " << h.compute(3) << "\n";
+}
+```
+
+```cpp
+// explicit_inst.cpp —— 集中显式实例化
+#include "heavy_template.h"
+template struct Heavy<int>;
+```
+
+编译链接运行(`use_a.cpp` 结构和 `use_b.cpp` 一样,只是没有 extern 那行):
+
+```bash
+$ g++ -std=c++20 -Wall -Wextra -c use_a.cpp use_b.cpp explicit_inst.cpp main.cpp
+$ g++ use_a.o use_b.o explicit_inst.o main.o -o demo && ./demo
+use_a: 85974
+use_b: 8768727
+```
+
+四个目标文件顺利编译,链接也通过,程序正常运行。机制本身没问题。
+
+更有意思的是看「不提供显式实例化定义会怎样」。把 `explicit_inst.cpp` 拿掉,只剩用了 extern 声明的 `use_b.cpp` 和 `main.cpp`:
+
+```text
+/usr/bin/ld: use_b.o: in function `use_b()':
+undefined reference to `Heavy<int>::Heavy(int)'
+undefined reference to `Heavy<int>::compute(int) const'
+```
+
+链接器找不到 `Heavy<int>` 的构造和 `compute` 的定义,报 undefined reference。这条报错把 extern template 的契约讲得很直白:您声明了「别处有定义」,就得真在某个翻译单元里把这个定义显式实例化出来,否则就是空头支票。配套使用时也别忘了:如果哪个翻译单元没用 extern 声明(比如这里的 `use_a.cpp`),它照样会隐式实例化一份——`extern template` 是「我这个 TU 不生成」,不是「全局只生成一份」。
+
+## 编译时间收益:别被「优化编译时间」的口号骗了
+
+讲到 extern template,几乎所有人都会说它「减少编译时间」。这话在原理上成立,但实际能省多少,值得跑跑看。GCC 有个 `-ftime-report` 标志,能在编译完输出各阶段耗时,里面有专门的 `template instantiation` 一项。先看一个小文件:
+
+```text
+$ g++ -std=c++20 -c -ftime-report use_b_noextern.cpp   # 隐式实例化版
+ template instantiation             :   0.08 ( 26%)    14M ( 23%)
+```
+
+模板实例化占了整个编译时间的大约四分之一,听上去 extern template 应该能帮上忙。咱们对比一下:同一个 `use_b.cpp`,一个版本带 extern 声明(不实例化 `Heavy<int>`),一个不带(隐式实例化),各跑三次看 `template instantiation` 那一行。
+
+| 文件 | 3 次 template instantiation |
+|---|---|
+| `use_b.cpp`(extern,不实例化) | 0.08 / 0.07 / 0.05 |
+| `use_b_noextern.cpp`(隐式实例化) | 0.07 / 0.05 / 0.05 |
+
+差异完全在噪声范围里,测不出谁更快。为了排除「模板太轻」的嫌疑,咱们把模板加重——内部塞了三组各 80 层的递归元函数(Fibonacci、三角形数、卢卡斯数),实例化 `Big<int>` 会连带展开约 240 个模板特化。再各跑三次:
+
+| 文件 | 3 次 template instantiation |
+|---|---|
+| `big_b.cpp`(extern) | 0.08 / 0.07 / 0.05 |
+| `big_b_noextern.cpp`(连带 240 个特化) | 0.07 / 0.05 / 0.05 |
+
+还是测不出来。现代编译器实例化这种「纯类型计算」的模板实在太快了,几千万分之一秒的活儿,被解析、优化这些阶段的噪声整个淹没。
+
+那 extern template 到底什么时候才真省时间?答案是**大型项目里,几十个翻译单元重复实例化同一个「重型」模板**。所谓重型,不是咱们这里的纯 TMP 递归,而是那种实例化会连带拉入一大片标准库代码的模板——比如某个泛型组件用了 `std::variant` 加一堆算法,它在二十个 `.cpp` 里被同样的参数用到,二十份重复实例化的成本才累积到肉眼可见。这种场景下,extern template 把二十遍压缩成一遍,收益就实打实了。所以判断要不要上 extern template,看的是「实例化的绝对成本」乘以「重复的翻译单元数」,两个都大才有意义。给一个只在小项目里用两三次的轻量模板加 extern,纯属徒增样板代码,该叫停。
+
+## 顺带说一句别的治编译时间的路子
+
+如果您的目标是「让编译更快」,extern template 往往不是杠杆最大的那个。更常奏效的几招:用前向声明代替不必要的 `#include`、把模板的声明和定义分开到不同头里减少实例化入口、上预编译头(PCH),以及 C++20 的 modules——modules 从机制上重新定义了「翻译单元之间怎么共享代码」,是治本的路子,虽然工具链支持到今天还在打磨。extern template 是这套工具箱里的一把小扳手,有它的用武之地,但不是主力。
+
+下一篇咱们看模板和异常怎么纠缠在一起:为什么 `vector` 扩容时要关心元素类型的 `noexcept`,以及 `move_if_noexcept` 这套机制怎么在「性能」和「异常安全」之间打圆场。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/07-template-instantiation-control.md
@@ -11,7 +11,7 @@ platform: host
 prerequisites:
 - TMP 核心技巧:concepts 之前的世界
 - Concepts:把模板约束写进签名
-reading_time_minutes: 14
+reading_time_minutes: 11
 related:
 - 静态反射基础:反射运算符与 splice 重组
 - 模板与异常安全:move_if_noexcept 与扩容

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
@@ -1,0 +1,167 @@
+---
+chapter: 13
+cpp_standard:
+- 11
+description: 模板和异常纠缠在一起的那条线:异常安全三档、noexcept 作为契约、move_if_noexcept 怎么在「可能回滚」时退回拷贝、vector 扩容凭什么保住强异常保证,以及模板里用条件 noexcept 把底层的是否抛异常如实传出去
+difficulty: intermediate
+order: 8
+platform: host
+prerequisites:
+- TMP 核心技巧:concepts 之前的世界
+- 模板实例化控制:extern template 与编译时间
+reading_time_minutes: 14
+related:
+- 模板实例化控制:extern template 与编译时间
+- 综合项目:concepts 约束的 mini-STL 算法库
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 类型安全
+- 内存管理
+title: 模板与异常安全:move_if_noexcept 与扩容
+---
+# 模板与异常安全:move_if_noexcept 与扩容
+
+上一篇末尾留了个话头:`vector` 扩容为什么要在意元素类型的 `noexcept`。这一篇就把这条线讲透。模板和异常看起来是两个不相干的话题,但只要您写过容器或者泛型算法,它们就会在「扩容时该 move 还是 copy」这种地方撞到一起。核心是两个工具:`std::move_if_noexcept` 和条件 `noexcept`。理解了它们,您就理解了为什么大家都反复强调「move 构造函数能 noexcept 就一定要 noexcept」。
+
+## 先把异常安全的几档说清楚
+
+异常安全有几档约定俗成的保证,先快速过一遍,后面用的主要是前两档。
+
+- **基本保证**:函数要么成功,要么抛异常,但即便抛了也不会泄漏资源、不会把对象留在损坏的状态。
+- **强保证**(strong guarantee):函数要么成功,要么「像没调用过一样」,整个程序状态回滚到调用前。
+- **不抛保证**(`noexcept`):函数保证不抛异常。
+
+强保证比基本保证严格得多,它要求「能回滚」。这一篇的主线就是:`vector` 扩容想保住强保证,而这个目标直接决定了它搬元素时该 move 还是 copy。
+
+## noexcept 是给调用方的契约
+
+`noexcept` 这个关键字,经常被误解成「我尽量不抛」。它真正的意思是「我保证不抛」,一旦函数真抛了异常,程序直接 `std::terminate`,不展开、不传播。所以 `noexcept` 不是写给函数自己的,是写给**调用方**的契约——调用方看到 `noexcept`,就可以放心做优化。
+
+对这一篇最重要的优化是:`noexcept` 的 move 才敢被用在「不能中途失败」的场景。`vector` 扩容搬元素就是这么个场景。如果您的 move 构造函数标了 `noexcept`,`vector` 扩容时就敢用它搬;没标,`vector` 就不敢,宁可去 copy。这个差别下面会实跑出来。
+
+## move_if_noexcept:可能要回滚时,退回拷贝
+
+C++11 给了一个工具 `std::move_if_noexcept`,它把「move」和「强异常保证」的张力收进了一个函数。行为很直白:如果 `T` 的 move 构造是 `noexcept` 的,它返回右值引用(走 move);否则返回 const 左值引用(走 copy)。
+
+```cpp
+// 大意(标准库的真实实现等价于这个判断)
+template <typename T>
+conditional_t<is_nothrow_move_constructible_v<T> && !is_lvalue_reference_v<T>,
+              T&&, const T&>
+move_if_noexcept(T& x) noexcept;
+```
+
+为什么需要这么个东西?设想一个「搬完可能要回滚」的操作:把一批元素从旧内存搬到新内存,搬到一半某个 move 抛了。如果用的是 move,被搬的元素可能已经被从旧内存里掏走了一半,状态乱了,想回滚也回滚不回去,强保证就没了。如果用的是 copy,copy 抛了的时候,旧内存里的原始元素根本没被动过,回滚就是「释放新内存」,干干净净。所以「可能要回滚」的场合,move 不够安全就该退回 copy,这就是 `move_if_noexcept` 的用途。咱们实测一下:
+
+```cpp
+struct NothrowMove {
+    int* p;
+    explicit NothrowMove(int v) : p(new int(v)) {}
+    NothrowMove(const NothrowMove& o) : p(new int(*o.p)) { std::cout << "    copy\n"; }
+    NothrowMove(NothrowMove&& o) noexcept : p(o.p) { o.p = nullptr; std::cout << "    move\n"; }
+};
+
+struct ThrowingMove {
+    int* p;
+    explicit ThrowingMove(int v) : p(new int(v)) {}
+    ThrowingMove(const ThrowingMove& o) : p(new int(*o.p)) { std::cout << "    copy\n"; }
+    ThrowingMove(ThrowingMove&& o) noexcept(false) : p(o.p) { o.p = nullptr; std::cout << "    move\n"; }
+};
+```
+
+<OnlineCompilerDemo allow-run
+  title="move_if_noexcept:按 noexcept 在 move/copy 间挑"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/move_if_noexcept_demo.cpp"
+  description="NothrowMove 走移动、ThrowingMove 退回拷贝,看 move_if_noexcept 怎么按 noexcept 决定。"
+/>
+
+运行结果:
+
+```text
+is_nothrow_move_constructible:
+  NothrowMove:  true
+  ThrowingMove: false
+move_if_noexcept 对 NothrowMove(应为 move):
+    [NothrowMove] 被移动
+move_if_noexcept 对 ThrowingMove(应为 copy):
+    [ThrowingMove] 被拷贝
+```
+
+`NothrowMove` 的 move 是 `noexcept`,所以 `move_if_noexcept` 给了右值引用,走 move;`ThrowingMove` 的 move 标了 `noexcept(false)`,可能抛,`move_if_noexcept` 退回给 const 引用,走 copy。这就是它「看 noexcept 决定 move 还是 copy」的行为。
+
+## vector 扩容凭什么保住强异常保证
+
+`std::vector` 在元素装满后再 `push_back`,会分配一块更大的新内存,把旧元素搬过去,再释放旧内存。这个「搬」用的就是 `move_if_noexcept`。咱们直接看不同元素类型下,扩容时的 copy/move 调用:
+
+<OnlineCompilerDemo allow-run
+  title="vector 扩容的 move vs copy,看强异常保证"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/vector_realloc.cpp"
+  description="扩容时 NothrowMove 被 move、ThrowingMove 被 copy,实证 vector 为保强保证付出的代价。"
+/>
+
+运行结果:
+
+```text
+vector<NothrowMove> 预留 2,再 push 第三个触发扩容:
+  >>> 扩容时(move noexcept,应为 move):
+    move
+    move
+
+vector<ThrowingMove> 预留 2,再 push 第三个触发扩容:
+  >>> 扩容时(move 可能抛,应为 copy 保强异常保证):
+    copy
+    copy
+```
+
+`NothrowMove` 的 move 是 `noexcept`,`vector` 扩容放心地 move,又快又不抛;`ThrowingMove` 的 move 可能抛,`vector` 不敢用,老老实实 copy。copy 比 move 慢(要深拷贝 `int*` 指向的内容),但这是保强保证的代价:万一 copy 中途抛了,旧内存里的元素原封不动,`vector` 能回滚到扩容前的状态。
+
+::: warning 您的 move 构造函数没标 noexcept,vector 就会 copy
+这是这一篇最实在的教训。很多初学者写完一个类的 move 构造函数,觉得「反正不会抛」就不标 `noexcept`。结果这个类塞进 `vector` 里,每次扩容都被 copy 一遍,白白损失了 move 的性能,而且编译器不会给您任何提示。规则记死:move 构造、move 赋值,只要您确定它不会抛(通常它只是在搬指针和几个基础类型),就一定要加 `noexcept`。这不只是风格,是实打实的性能开关。
+:::
+
+当然不是所有 move 都能 `noexcept`。如果一个 move 内部要分配内存(比如 move 一个 `std::vector` 的元素,可能要分配新 `vector`),分配可能抛,那就不能瞎标。标准库的 `std::vector` 自己的 move 构造是 `noexcept` 的,因为它只是偷对方的内部指针,不分配。判断标准很朴素:move 里干了什么,有没有可能抛。
+
+## 条件 noexcept:把底层会不会抛如实传出去
+
+模板函数自己不知道它操作的类型 `T` 会不会抛,但它可以「继承」这个信息,靠的是**条件 noexcept**:`noexcept(noexcept(表达式))`。外层 `noexcept` 是说明符,内层 `noexcept(...)` 是运算符(在编译期求值,问「这个表达式是不是 noexcept」)。合起来就是「我这个函数的 noexcept 性,等于底层那个表达式的 noexcept 性」。
+
+```cpp
+// 没标 noexcept:调用方只能保守地认为它可能抛
+template <typename T>
+void uncond_op(T& x) {
+    T tmp(std::move(x));
+    x = std::move(tmp);
+}
+
+// 条件 noexcept:继承 T 的 move 构造是否 noexcept
+template <typename T>
+void cond_op(T& x) noexcept(noexcept(T(std::move(x)))) {
+    T tmp(std::move(x));
+    x = std::move(tmp);
+}
+```
+
+跑一下,看两种写法在调用方眼里的 noexcept 性:
+
+<OnlineCompilerDemo allow-run
+  title="条件 noexcept:把底层会不会抛如实传出去"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/noexcept_propagation.cpp"
+  description="没标 noexcept 的模板被保守认为可能抛,noexcept(noexcept(...)) 让 noexcept 性跟着底层走。"
+/>
+
+运行结果:
+
+```text
+uncond_op<NoThrowMove> noexcept: false
+cond_op<NoThrowMove> noexcept:   true
+cond_op<ThrowMove> noexcept:     false
+```
+
+`uncond_op` 哪怕底层类型 move 是 noexcept,自己没标,调用方查出来还是 `false`——它白白丢掉了这个信息。`cond_op` 用条件 noexcept 把底层的 truth 传了出来:底层 move noexcept 时它就 noexcept,底层可能抛时它也如实是 `false`。这一条在写泛型容器、算法时很要紧:您的 `swap`、`move`、`emplace` 这些操作如果不用条件 noexcept,就会在整条调用链上把「本来 noexcept」的操作误报成「可能抛」,下游容器一查就退回 copy,move 的优化全丢了。
+
+## 串起来
+
+这一篇的几样东西是同一条逻辑串起来的。`noexcept` 是给调用方的契约,说「我不抛」;`move_if_noexcept` 利用这个契约,在「可能要回滚」的场合挑是 move 还是 copy;`vector` 扩容正是这样的场合,所以它根据元素 move 是否 noexcept 决定 move 还是 copy;条件 `noexcept` 则让模板函数能把底层的 noexcept 性如实往上传。所以一个看似只是「写法问题」的 `noexcept` 标注,实际上是 move 性能能不能兑现的关键。下一篇咱们把这些元编程的本事攒到一起,做一个用 concepts 约束的 mini-STL 算法库当收尾。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/08-templates-and-exception-safety.md
@@ -9,7 +9,7 @@ platform: host
 prerequisites:
 - TMP 核心技巧:concepts 之前的世界
 - 模板实例化控制:extern template 与编译时间
-reading_time_minutes: 14
+reading_time_minutes: 12
 related:
 - 模板实例化控制:extern template 与编译时间
 - 综合项目:concepts 约束的 mini-STL 算法库

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
@@ -1,0 +1,151 @@
+---
+chapter: 13
+cpp_standard:
+- 20
+description: 把这一卷讲过的 concepts、requires、TMP、异常安全焊成一个东西:用 C++20 concepts 约束的 mini-STL 算法库。实现 transform、accumulate、find_if,配上恰当约束,看 concepts 在真实泛型库里带来的签名清晰与报错友好
+difficulty: intermediate
+order: 9
+platform: host
+prerequisites:
+- Concepts:把模板约束写进签名
+- 使用 Concepts 约束模板:subsumption 与重载
+- Requires 表达式深度解析:四种成分
+- TMP 核心技巧:concepts 之前的世界
+reading_time_minutes: 16
+related:
+- Concepts:把模板约束写进签名
+- 模板与异常安全:move_if_noexcept 与扩容
+tags:
+- host
+- cpp-modern
+- intermediate
+- 模板
+- 泛型
+- concepts
+- 编译期计算
+title: 综合项目:concepts 约束的 mini-STL 算法库
+---
+# 综合项目:concepts 约束的 mini-STL 算法库
+
+子卷走到这里,概念性的东西讲了一圈:concepts 怎么写、requires 表达式的四种成分、TMP 的老技巧、编译期字符串、C++26 反射、实例化控制、异常安全。这一篇把这些东西焊起来,做一个实际的东西——一个用 concepts 约束的 mini-STL 算法库。咱们实现三个经典算法:`transform`、`accumulate`、`find_if`,给它们配上恰当的约束,看看 concepts 在一个真实的泛型库里到底带来了什么。不卖关子,就两样:签名读得懂了,报错也说人话了。
+
+## 目标:三个算法,签名即文档
+
+先定要做的事。`transform` 把一个 range 的元素经函数变换后写到输出;`accumulate` 把 range 的元素累加起来;`find_if` 找第一个满足谓词的元素。这三个算法标准库都有(`std::ranges::transform` 等),咱们重写一遍的目的不是替代它们,而是把这一卷学的东西攒到一个能跑的例子里。
+
+设计上的一个原则:**每个算法的模板参数都用 concept 约束,读签名就能知道它要什么**。下面逐个看。
+
+## 两个自定义 concept:给标准库没现成的需求起名
+
+标准库 `<concepts>` 和 `<iterator>` 提供了一批现成概念(`input_iterator`、`predicate`、`invocable`、`convertible_to`……),大部分需求都能直接用。但有两个需求标准库没现成的,咱们自己起名:
+
+```cpp
+template <typename T, typename U = T>
+concept Addable = requires(T a, U b) {
+    { a + b } -> std::convertible_to<U>;
+};
+
+template <typename T>
+concept Ordered = requires(T a, T b) {
+    { a < b } -> std::convertible_to<bool>;
+};
+```
+
+`Addable<T, U>` 问的是「`T` 和 `U` 能相加,且结果能转成 `U`」。默认 `U = T`,所以 `Addable<int>` 就是「int 能和自己加」。`Ordered` 问「能不能用 `<` 比较,结果是 bool」。这俩名字一立起来,后面算法的签名就有的写了。这一步对应的是 03 篇讲的 requires 表达式的复合要求:`{ a + b } -> std::convertible_to<U>` 既检查表达式合法,又检查返回类型满足约束。
+
+## transform:用现成的 range 和迭代器概念
+
+```cpp
+template <std::ranges::input_range R, typename Out, typename F>
+    requires std::output_iterator<Out, std::ranges::range_value_t<R>>
+          && std::invocable<F&, std::ranges::range_reference_t<R>>
+Out transform(R&& r, Out out, F f) {
+    for (auto&& x : r) {
+        *out++ = std::invoke(f, x);
+    }
+    return out;
+}
+```
+
+这个签名读起来就是文档本身:`R` 是个 input range,`Out` 是个 output iterator(能写 `R` 的元素类型),`F` 是个可调用对象(能接受 `R` 的元素引用)。三个要求都摆在模板参数列表和 requires 子句里,没有半个 `enable_if` 套娃。
+
+这里有个 03 篇讲过的细节值得复读:`std::invocable<F&, std::ranges::range_reference_t<R>>` 里用的 `range_reference_t<R>`,不是 `range_value_t<R>`。因为遍历 range 拿到的是元素的**引用**,函数要能接受引用类型才合规。这种「把类型算对」的活,在 concepts 之前要靠 `decltype` 和 `std::declval` 绕一圈,现在标准库的别名(`range_value_t`、`range_reference_t`)直接给到。
+
+## accumulate:自定义 Addable 上场
+
+```cpp
+template <std::ranges::input_range R, typename T>
+    requires Addable<T, std::ranges::range_value_t<R>>
+T accumulate(R&& r, T init) {
+    for (auto&& x : r) {
+        init = init + x;
+    }
+    return init;
+}
+```
+
+约束是 `Addable<T, range_value_t<R>>`:累加值类型 `T` 要能和 range 的元素类型相加。这就比标准库 `std::accumulate` 的「无约束模板」更直白——标准库那个传错类型时,报错会一路钻进 `operator+` 的替换失败里,而咱们这个会直接说「`Addable` 没满足」。`Addable` 的好处还在于它**不限于数值**:只要类型有 `operator+` 且结果能转回来,`std::string` 一样能 accumulate(下面实测会看到)。
+
+## find_if:用 std::predicate
+
+```cpp
+template <std::ranges::input_range R, typename Pred>
+    requires std::predicate<Pred&, std::ranges::range_reference_t<R>>
+std::ranges::borrowed_iterator_t<R> find_if(R&& r, Pred pred) {
+    for (auto it = std::ranges::begin(r); it != std::ranges::end(r); ++it) {
+        if (std::invoke(pred, *it)) return it;
+    }
+    return std::ranges::end(r);
+}
+```
+
+`std::predicate<Pred&, T>` 比 `std::invocable` 更严:不仅要求能调用,还要求返回类型能转成 `bool`。`find_if` 的谓词当然得返回 bool,用 `predicate` 比 `invocable` 更贴。返回类型 `borrowed_iterator_t<R>` 是 ranges 里的一个细节,处理「传临时 range 进来时迭代器会不会悬空」的问题,这里不展开。
+
+## 跑起来
+
+把三个算法一起跑,测试覆盖数值、字符串、谓词几种场景:
+
+<OnlineCompilerDemo allow-run
+  title="concepts 约束的 mini-STL:transform / accumulate / find_if"
+  source-path="code/examples/vol4/vol3-metaprogramming-cpp20-23/mini_stl.cpp"
+  description="transform 平方、accumulate 求和与拼接、find_if 找偶数,同一个 accumulate 既能加整数也能拼字符串。"
+/>
+
+运行结果:
+
+```text
+transform 平方: 1 4 9 16
+accumulate 求和:  10
+accumulate 拼接:  start:abc
+find_if 第一个偶数: 2
+```
+
+四行输出都符合预期。`transform` 把 `{1,2,3,4}` 平方成 `{1,4,9,16}`;`accumulate` 求和得 10;第三个最有意思,`accumulate` 拼接字符串得 `start:abc`——同一个算法,既能加整数,也能拼字符串,因为 `Addable` 只认 `operator+`,不预设是数值。这就是泛型的价值,而 concepts 让这个泛型既灵活(任何 Addable 类型)又安全(不 Addable 的进不来)。
+
+## 传错类型,报错说人话
+
+最有说服力的是看它怎么拒绝错的类型。咱们定义一个没有 `operator+` 的 `NoPlus`,拿它去调 `accumulate`:
+
+```cpp
+struct NoPlus {};
+std::vector<NoPlus> v(3);
+my::accumulate(v, NoPlus{});   // Addable 约束不满足
+```
+
+```text
+constraints not satisfied
+required for the satisfaction of 'Addable<T, std::ranges::range_value_t<_Range>>'
+    [with T = NoPlus; R = std::vector<NoPlus, ...>&]
+```
+
+把这一段和 04 篇里 `enable_if` 那套天书对比一下。那边是 `no type named 'type' in 'std::enable_if<false, void>'`,通篇在讲 `enable_if` 的内部机制;这边直接说 `Addable<NoPlus, ...>` 没满足,把约束的名字和具体的类型都点了出来。读者不用懂 SFINAE,一眼就知道「哦,`NoPlus` 不能相加」。01 篇讲 concept 报错时说的「少掉一半头发」,在真实的泛型库里就是这么兑现的。
+
+## concepts 给泛型库带来了什么
+
+把这三段代码和一个等价的 C++17 `enable_if` 版本放一起,差别就清楚了。concepts 给泛型库带来三样实在的东西。
+
+一是**签名即文档**。`requires input_range<R> && output_iterator<Out, ...>` 这种写法,读签名就知道算法要什么,不用钻进实现去看它到底对参数做了什么假设。二是**报错点名约束**。传错类型时,编译器说的是「哪个 concept 没满足」,而不是「enable_if 替换失败」。三是**约束可复用、可组合**。`Addable` 定义一次,任何需要「能相加」的算法都能用;多个 concept 用 `&&` 组合,还能靠 02 篇讲的 subsumption 规则参与重载分派。这三样加起来,就是从「写得出泛型代码」到「写得舒服、读得明白、错得起」的跨越。
+
+## 子卷收官
+
+这一卷从 concepts 起手,讲清了约束怎么写、怎么参与重载、requires 表达式的四种成分;然后倒回去看 TMP 的老本事——type_traits 的特化内幕、模板递归、SFINAE、`void_t`、fold expressions,以及怎么把这些往 concepts 上迁;接着是编译期字符串和 C++20 的 NTTP class type;再往 C++26 看了一眼静态反射;最后回到工程层面,讲模板实例化怎么控制、模板和异常怎么纠缠,并用这个 mini-STL 算法库把主线焊在一起。concepts 是这一卷的脊柱,但它不是全部——TMP 的递归和特化、fold expressions、条件 noexcept,这些在 concepts 出现之后仍然是写泛型代码的日常工具。读完这一卷,您应该既会用 C++20 的新办法写约束,也读得懂老库里 SFINAE 和 `void_t` 的写法,并且知道什么时候该用哪个。

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/09-mini-stl-with-concepts.md
@@ -11,7 +11,7 @@ prerequisites:
 - 使用 Concepts 约束模板:subsumption 与重载
 - Requires 表达式深度解析:四种成分
 - TMP 核心技巧:concepts 之前的世界
-reading_time_minutes: 16
+reading_time_minutes: 11
 related:
 - Concepts:把模板约束写进签名
 - 模板与异常安全:move_if_noexcept 与扩容

--- a/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/index.md
+++ b/documents/vol4-advanced/vol3-metaprogramming-cpp20-23/index.md
@@ -7,7 +7,7 @@ description: "C++20/23 元编程：Concepts、requires 表达式、TMP 核心技
 
 本部分接着 vol1 的模板基础往下走。vol1 讲的是模板的编译模型、特化、两阶段查找这些「机制」,这一部分讲的是怎么用这些机制做**编译期计算和类型推导**,以及 C++20 的 Concepts 如何把过去依赖 SFINAE、`enable_if` 的苦活改写成可读的约束。
 
-三条主线:Concepts 和 requires 表达式(C++20)、经典模板元编程(TMP)技巧和它的现代化、编译期字符串与 C++26 反射。每篇都带「上手跑一跑」的真实编译输出,该踩的坑写成 `::: warning` 预警块,关键的编译期行为用汇编佐证。
+三条主线:Concepts 和 requires 表达式(C++20)、经典模板元编程(TMP)技巧和它的现代化、编译期字符串与 C++26 反射。
 
 配套可运行示例在 [code/examples/vol4/vol3-metaprogramming-cpp20-23/](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/examples/vol4/vol3-metaprogramming-cpp20-23),每个文件 `g++ -std=c++20 xxx.cpp` 直接跑。
 
@@ -15,6 +15,12 @@ description: "C++20/23 元编程：Concepts、requires 表达式、TMP 核心技
   <ChapterLink href="01-concepts">Concepts:把模板约束写进签名</ChapterLink>
   <ChapterLink href="02-constraining-templates">使用 Concepts 约束模板:subsumption 与重载</ChapterLink>
   <ChapterLink href="03-requires-expressions">Requires 表达式深度解析:四种成分</ChapterLink>
+  <ChapterLink href="04-tmp-core-techniques">TMP 核心技巧:concepts 之前的世界</ChapterLink>
+  <ChapterLink href="05-compile-time-strings">编译期字符串:NTTP class type 与 fixed_string</ChapterLink>
+  <ChapterLink href="06-static-reflection-basics">静态反射基础:反射运算符与 splice 重组</ChapterLink>
+  <ChapterLink href="07-template-instantiation-control">模板实例化控制:extern template 与编译时间</ChapterLink>
+  <ChapterLink href="08-templates-and-exception-safety">模板与异常安全:move_if_noexcept 与扩容</ChapterLink>
+  <ChapterLink href="09-mini-stl-with-concepts">综合项目:concepts 约束的 mini-STL 算法库</ChapterLink>
 </ChapterNav>
 
-Concepts 三连(01-03)是这一部分的地基,讲清约束怎么写、怎么参与重载、requires 表达式的四种成分和它的两个坑。后续会接着讲:TMP 核心技巧(type_traits 内幕、`void_t` SFINAE、typelist、fold expressions,以及 SFINAE 往 concepts 的迁移)、编译期字符串处理(C++20 NTTP 的 class type 与 `fixed_string`)、C++26 静态反射(P2996 的 `^` 与 `[: :]`)、模板实例化控制、模板与异常安全,最后用一个 concepts 约束的 mini-STL 算法库把前面焊在一起。
+Concepts 三连(01-03)是地基,讲清约束怎么写、怎么参与重载、requires 表达式的四种成分和它的两个坑。04 倒回去讲 TMP 老技巧(`type_traits` 内幕、模板递归、SFINAE、`void_t`、fold expressions)和 SFINAE 往 concepts 的迁移;05 讲编译期字符串(C++20 NTTP class type 与 `fixed_string`);06 看一眼 C++26 静态反射(P2996 的反射运算符与 splice);07 讲模板实例化控制(`extern template` 与编译时间);08 讲模板与异常安全(`move_if_noexcept` 与容器扩容);最后 09 用一个 concepts 约束的 mini-STL 算法库把前面焊在一起。

--- a/documents/vol4-advanced/vol4-generics-patterns/index.md
+++ b/documents/vol4-advanced/vol4-generics-patterns/index.md
@@ -9,8 +9,6 @@ description: "GoF 设计模式的现代 C++ 实现:演进式讲清每个模式�
 
 和「定义 + UML + 例子」式的传统讲法不同,我们的路子是**从最直觉、最原始的写法起步,一步步逼出每个模式**——讲清楚它到底在解决什么问题、每一步演进为什么还不够、以及到了 C++17/20 有了 `std::variant` / concepts / CRTP / 模板之后,同一个模式能写出怎样更安全、更零开销的版本。
 
-贯穿全卷的几个写法特点:每个模式都带「这里先验证一下」的真实终端输出(不是纸上谈兵);该踩的坑写成 `::: warning` 预警块;凡是能用现代 C++ 替代的旧写法,都把「经典 vs 现代」摆在一起比。
-
 配套可编译工程在仓库的 [code/volumn_codes/vol4/design-patterns/](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/tree/main/code/volumn_codes/vol4/design-patterns) 下,每个模式一个独立 CMake 子工程,`cmake -S . -B build && cmake --build build` 即可跑。
 
 ## 创造型(Creational)


### PR DESCRIPTION
- 04-09 CN: TMP techniques, compile-time strings, C++26 reflection, instantiation control, exception safety, mini-STL with concepts
- EN translation for the whole sub-volume (01-09), voice-aligned with vol1
- 32 OnlineCompilerDemo (CN+EN) with allow-run, replacing bash run blocks
- outputs aligned to actual runs (stdconcepts 11 lines, requires_expression)
- subsumption demo: basic section links to full file on GitHub, full OnlineDemo moved after conjunction to avoid spoiling Both/C early
- fix: add allow-run to vol2/05 push_back & noexcept_sort demos
- cleanup: drop self-congratulatory sentences from vol4 three sub-volume indexes