### PR TITLE
fix: getting started 404 fix

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -23,6 +23,7 @@ interface Volume {
 }
 
 const VOLUMES: Volume[] = [
+  { name: 'gettting-started', srcDir: 'gettting-started', urlPrefix: '/gettting-started' },
   { name: 'vol1', srcDir: 'vol1-fundamentals', urlPrefix: '/vol1-fundamentals' },
   { name: 'vol2', srcDir: 'vol2-modern-features', urlPrefix: '/vol2-modern-features' },
   { name: 'vol3', srcDir: 'vol3-standard-library', urlPrefix: '/vol3-standard-library' },


### PR DESCRIPTION
remote gettting started is not available, so now it is available as i forgot to add it into the build reference
