### PR TITLE
docs(c): 完善结构体与联合体章节练习答案

### DIFF
--- a/documents/en/compilation/02-reuse-concept.md
+++ b/documents/en/compilation/02-reuse-concept.md
@@ -51,7 +51,7 @@ A static library is probably way simpler than you think. We know that after the 
 
 The two figures below do a decent job of showing what a static library does.
 
-![static_library](./compilation-linking-2-reuse-concept/static_library.png)
+![static_library](../../compilation/compilation-linking-2-reuse-concept/static_library.png)
 
 But this introduces a new problem. In reality, libfoo's code is exactly the same in two places, and there are now two copies of it. Sometimes we really don't want this kind of hard copy. If libfoo is small it's fine, and disk space isn't all that expensive anymore, so we can sort of call it redundancy-as-an-advantage. But more often, if libfoo ships an important security update and we want every piece of software to pick it up on its next launch, the static library looks pretty helpless. All it really did was shift distribution from the harder source-distribution model over to binary distribution. It does absolutely nothing about the much more important "load it when you use it" problem. So it's just not that elegant. In practice, static libraries aren't used all that widely (I barely use them myself, either).
 
@@ -120,7 +120,7 @@ To resolve a given symbol (say the function `foo`), the loader's lookup order is
 
 > Important: **symbols in the executable take priority** over those in shared libraries (this is what's called symbol interposition), so an executable can "override" functions in a library (this is also the foundation of how `LD_PRELOAD` can swap out a function's implementation).
 
-![dynamic_library](./compilation-linking-2-reuse-concept/dynamic_library.png)
+![dynamic_library](../../compilation/compilation-linking-2-reuse-concept/dynamic_library.png)
 
 That figure above lays the whole flow out clearly.
 

--- a/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
+++ b/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
@@ -99,7 +99,7 @@ SensorReading r3 = {
 
 指定初始化器的好处非常明显：代码自文档化，不依赖字段顺序，未指定的字段自动清零。说实话，在现代 C 代码中，只要你用的编译器支持 C99（基本上都支持），就应该优先使用指定初始化器。
 
-结构体的赋值和初始化是两回事。初始化发生在声明时，赋值发生在声明之后。C 语言允许同类型的结构体之间直接赋值，这是逐字节复制的：
+结构体的赋值和初始化是两回事。初始化发生在声明时，赋值发生在声明之后。C 语言允许同类型的结构体之间直接赋值，赋值后各个成员的值与源对象对应成员相同：
 
 ```c
 SensorReading r4;
@@ -236,7 +236,7 @@ printf("alignof(double)   = %zu\n", alignof(double));    // 通常 8
 printf("alignof(WeirdLayout) = %zu\n", alignof(WeirdLayout)); // 4
 ```
 
-结构体的对齐要求等于其成员中最大的对齐要求。`WeirdLayout` 里有 `uint32_t`，所以整体对齐要求是 4。
+在没有额外对齐说明时，大多数 ABI 会让结构体的对齐要求不低于其成员中最严格的一项。`WeirdLayout` 里有 `uint32_t`，因此当前实验环境中整体对齐要求是 4；需要跨平台确认时，仍应以 `alignof(WeirdLayout)` 的结果为准。
 
 ### alignas：强制对齐
 
@@ -332,7 +332,7 @@ free(pkt);
 
 柔性数组成员在通信协议、变长消息处理、数据包解析中用得非常多。在 C 的早期年代，人们用一种叫做"struct hack"的技巧来实现类似功能——在结构体末尾放一个长度为 1（或 0）的数组，然后多分配一些空间。但那是未定义行为，C99 的 FAM 才是标准做法。
 
-有一点需要注意：含柔性数组成员的结构体不能按值传递或复制——因为 `sizeof` 不知道尾部数据有多大。你只能通过指针来操作它们。
+有一点需要注意：含柔性数组成员的结构体**可以**按值传递、赋值或返回，但这些操作只复制固定成员，不会复制尾随数据。协议帧和变长消息通常仍应通过指针传递，或者显式分配目标缓冲区并复制完整字节范围；否则很容易误以为 payload 也一起被复制了。
 
 ## 结构体数组
 
@@ -392,7 +392,7 @@ typedef struct __attribute__((packed)) {
 
 加了这个属性后，`sizeof(PackedFrame)` 就是纯粹的 1 + 2 + 1 + 4 = 8 字节，没有任何填充。但要注意代价——访问未对齐的字段在某些架构上会导致性能下降甚至硬件异常。所以 `packed` 应该只在你确实需要紧凑布局的时候使用，而不是到处乱加。ARM Cortex-M 系列在大多数情况下能处理未对齐访问（有性能损失），但有些老架构（比如 ARM7TDMI）会直接 fault。
 
-一个更安全的做法是：**通信层用 packed 结构体解析原始字节，然后立即转换成对齐的内部结构体来使用**。解析和业务逻辑分离，各取所需。
+`packed` 只约束布局，既不处理大端、小端，也不会让任意 `uint8_t` 接收缓冲区都能安全地强转为结构体指针。更稳妥的做法是：通信层按字节读取，或先 `memcpy` 到对齐良好的临时对象后再逐字段解码；随后转换成自然对齐的内部结构体供业务代码使用。解析和业务逻辑分离，各取所需。
 
 ## C++ 衔接
 
@@ -493,6 +493,57 @@ typedef struct {
 
 ::: details 参考答案
 
+先把三个结构体补成完整程序，用 `offsetof` 和 `sizeof` 验证手算结果：
+
+```c
+#include <stddef.h>
+#include <stdio.h>
+
+typedef struct {
+    char a;
+    int b;
+    char c;
+} StructA;
+
+typedef struct {
+    int b;
+    char a;
+    char c;
+} StructB;
+
+typedef struct {
+    char a;
+    char c;
+    int b;
+} StructC;
+
+int main(void)
+{
+    printf("StructA: a=%zu, b=%zu, c=%zu, sizeof=%zu\n",
+           offsetof(StructA, a), offsetof(StructA, b),
+           offsetof(StructA, c), sizeof(StructA));
+    printf("StructB: a=%zu, b=%zu, c=%zu, sizeof=%zu\n",
+           offsetof(StructB, a), offsetof(StructB, b),
+           offsetof(StructB, c), sizeof(StructB));
+    printf("StructC: a=%zu, b=%zu, c=%zu, sizeof=%zu\n",
+           offsetof(StructC, a), offsetof(StructC, b),
+           offsetof(StructC, c), sizeof(StructC));
+    return 0;
+}
+```
+
+```bash
+gcc -std=c11 -Wall -Wextra alignment_verify.c -o alignment_verify && ./alignment_verify
+```
+
+在 `int` 为 4 字节、按 4 字节对齐的测试环境中，输出如下：
+
+```text
+StructA: a=0, b=4, c=8, sizeof=12
+StructB: a=4, b=0, c=5, sizeof=8
+StructC: a=0, b=4, c=1, sizeof=8
+```
+
 手算结果（`int` 4 字节对齐）：
 
 | 结构体 | a 偏移 | b 偏移 | c 偏移 | sizeof |
@@ -534,6 +585,71 @@ typedef struct {
 
 想一想：`FramePacked` 最省空间，但为什么在有些 CPU 上访问 `value` 字段反而更慢、甚至直接崩？什么场景该用 packed，什么场景该用显式对齐？
 
+::: details 参考答案
+
+下面的程序一次把三种布局打印出来。`__attribute__((packed))` 是 GCC/Clang 扩展，所以这里使用 GCC 编译：
+
+```c
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct {
+    uint8_t type;
+    uint32_t value;
+} FrameNormal;
+
+typedef struct __attribute__((packed)) {
+    uint8_t type;
+    uint32_t value;
+} FramePacked;
+
+typedef struct {
+    uint8_t type;
+    _Alignas(4) uint32_t value;
+} FrameAligned;
+
+int main(void)
+{
+    printf("FrameNormal: type=%zu, value=%zu, sizeof=%zu\n",
+           offsetof(FrameNormal, type), offsetof(FrameNormal, value),
+           sizeof(FrameNormal));
+    printf("FramePacked: type=%zu, value=%zu, sizeof=%zu\n",
+           offsetof(FramePacked, type), offsetof(FramePacked, value),
+           sizeof(FramePacked));
+    printf("FrameAligned: type=%zu, value=%zu, sizeof=%zu\n",
+           offsetof(FrameAligned, type), offsetof(FrameAligned, value),
+           sizeof(FrameAligned));
+    return 0;
+}
+```
+
+```bash
+gcc -std=c11 -Wall -Wextra packed_compare.c -o packed_compare && ./packed_compare
+```
+
+运行结果：
+
+```text
+FrameNormal: type=0, value=4, sizeof=8
+FramePacked: type=0, value=1, sizeof=5
+FrameAligned: type=0, value=4, sizeof=8
+```
+
+| 结构体 | `type` 偏移 | `value` 偏移 | `sizeof` |
+|---|---:|---:|---:|
+| `FrameNormal` | 0 | 4 | 8 |
+| `FramePacked` | 0 | 1 | 5 |
+| `FrameAligned` | 0 | 4 | 8 |
+
+`FramePacked` 的问题就在 `value`：它从偏移 1 开始，不能保证落在 4 字节边界上。对 x86 这类通常支持未对齐访问的 CPU，处理器往往还能把值读出来，但可能需要额外的访存操作；如果数据刚好跨过缓存行，代价会更明显。换到对齐要求严格的 CPU，编译器要么把一次读取拆成多次字节读取来绕开问题，要么生成的未对齐读取会触发硬件异常。尤其不要把 `&frame.value` 当作普通的 `uint32_t*` 传给别的接口，这个指针的对齐条件已经不可靠了。
+
+所以 `packed` 不是一个"省空间就加上"的开关。它适合必须逐字节匹配外部格式的地方，例如通信协议帧、文件头或 Flash 中的固定记录；而且它只解决布局，不会自动处理大端、小端。工程上更稳妥的做法是：收发层按字节读取或用 `packed` 描述外部格式，完成长度和字节序检查后，立刻复制、解码到正常对齐的内部结构体，再交给业务代码使用。热路径数据、结构体数组、原子变量，以及 DMA 缓冲区等对访问效率或硬件约束敏感的对象，都不该为了省几个字节贸然打包。
+
+`_Alignas` 则是反过来的工具：它是在 C11 中显式保证对象或成员满足较高的对齐要求。在这个例子里，`uint32_t` 本来就自然按 4 字节对齐，所以 `FrameAligned` 和 `FrameNormal` 的布局相同；它的价值在于把约束写在代码里，例如 DMA 缓冲区需要 32 字节对齐，或某个成员必须从指定边界开始。记住这一条就够了：外部字节格式优先考虑 `packed`，内存中的日常数据优先保持自然对齐；两者之间用一次明确的解析和转换隔开，后面的代码就不用一直背着对齐风险跑。
+
+:::
+
 ### 练习 3：通信协议帧设计（挑战·可选）
 
 **难度：挑战** · 可选，需要了解 CRC 与字节序，新手可跳过
@@ -546,9 +662,542 @@ typedef struct {
 
 提示：本篇讲过柔性数组成员、`_Alignas`、`__attribute__((packed))`、`offsetof`，这些都是你的工具。CRC 算法和字节序转换属于通信专题，这里只要求你意识到这两个问题、留好占位，不要求完整实现。
 
+::: details 参考答案
+
+
+
+crc_ref.h
+
+```c
+#ifndef CRC_REF_H
+#define CRC_REF_H
+
+#include <stdint.h>
+
+//* 系统 CRC 工具接口。
+//? CRC8 通常放在帧头末尾，CRC16 放在整帧末尾；这些接口直接在调用方提供的
+//? 字节缓冲区上计算、校验或回填校验值，不申请额外内存。
+//! 保留 TRUE/FALSE 无符号宏是为了兼容裁判系统旧代码中直接比较宏返回值的写法。
+#define TRUE 1u
+#define FALSE 0u
+
+//* 将 CRC8 写入消息/帧头缓冲区的最后 1 字节。
+//? dwLength 必须把目标 CRC8 字节也计算在内。
+//! pchMessage 为空或长度不足以容纳有效数据和 CRC8 时，函数会直接返回。
+void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
+
+//* 校验消息/帧头最后 1 字节是否匹配 CRC8。
+//? 对前 dwLength - 1 字节重新计算 CRC8，和末尾保存的校验字节一致时返回 TRUE。
+uint32_t Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
+
+//* 使用调用方给定的初值计算 dwLength 字节的 CRC8。
+//? 传入上一次返回的 CRC 值可以继续分段计算。
+//! dwLength 非 0 时，调用方必须保证 pchMessage 指向有效缓冲区。
+uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
+                           uint8_t ucCRC8);
+
+//* 将 CRC16 写入完整帧缓冲区的最后 2 字节。
+//? 系统帧格式按小端保存 CRC16：低字节在前，高字节在后。
+//! dwLength 必须把 2 个 CRC16 目标字节也计算在内。
+void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
+
+//* 校验完整帧末尾 2 字节是否匹配 CRC16。
+//? 对前 dwLength - 2 字节重新计算 CRC16，再和末尾的小端 CRC16 尾部比较。
+uint32_t Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
+
+//* 使用调用方给定的初值计算 dwLength 字节的 CRC16。
+//? 既可用于整帧计算，也可用于分段累积计算。
+//! pchMessage 为空时返回 0xffffu，以保持原有防御性行为。
+uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
+                             uint16_t wCRC);
+
+#endif
+
+
+```
+
+crc_ref.c
+
+```c
+
+#include "crc_ref.h"
+
+#include <stddef.h>
+
+//* 系统协议 CRC 实现。
+//? 查表法把逐位多项式计算压缩为“每字节一次索引读取”，适合放在接收解析、
+//? 中断后处理或高频通信路径中快速校验帧数据。
+//! CRC 初值和 CRC16 写入字节序都属于协议约束，随意修改会导致系统帧校验失败。
+
+//* 系统帧头 CRC8 使用的初始值。
+static const uint8_t k_crc8_init = 0xffu;
+
+//* CRC8 预计算状态转移表。
+//? 每轮使用 current_crc ^ next_byte 作为索引，表项就是折叠该字节后的下一 CRC 状态。
+static const uint8_t k_crc8_tab[256] = {
+    0x00, 0x5e, 0xbc, 0xe2, 0x61, 0x3f, 0xdd, 0x83, 0xc2, 0x9c, 0x7e, 0x20,
+    0xa3, 0xfd, 0x1f, 0x41, 0x9d, 0xc3, 0x21, 0x7f, 0xfc, 0xa2, 0x40, 0x1e,
+    0x5f, 0x01, 0xe3, 0xbd, 0x3e, 0x60, 0x82, 0xdc, 0x23, 0x7d, 0x9f, 0xc1,
+    0x42, 0x1c, 0xfe, 0xa0, 0xe1, 0xbf, 0x5d, 0x03, 0x80, 0xde, 0x3c, 0x62,
+    0xbe, 0xe0, 0x02, 0x5c, 0xdf, 0x81, 0x63, 0x3d, 0x7c, 0x22, 0xc0, 0x9e,
+    0x1d, 0x43, 0xa1, 0xff, 0x46, 0x18, 0xfa, 0xa4, 0x27, 0x79, 0x9b, 0xc5,
+    0x84, 0xda, 0x38, 0x66, 0xe5, 0xbb, 0x59, 0x07, 0xdb, 0x85, 0x67, 0x39,
+    0xba, 0xe4, 0x06, 0x58, 0x19, 0x47, 0xa5, 0xfb, 0x78, 0x26, 0xc4, 0x9a,
+    0x65, 0x3b, 0xd9, 0x87, 0x04, 0x5a, 0xb8, 0xe6, 0xa7, 0xf9, 0x1b, 0x45,
+    0xc6, 0x98, 0x7a, 0x24, 0xf8, 0xa6, 0x44, 0x1a, 0x99, 0xc7, 0x25, 0x7b,
+    0x3a, 0x64, 0x86, 0xd8, 0x5b, 0x05, 0xe7, 0xb9, 0x8c, 0xd2, 0x30, 0x6e,
+    0xed, 0xb3, 0x51, 0x0f, 0x4e, 0x10, 0xf2, 0xac, 0x2f, 0x71, 0x93, 0xcd,
+    0x11, 0x4f, 0xad, 0xf3, 0x70, 0x2e, 0xcc, 0x92, 0xd3, 0x8d, 0x6f, 0x31,
+    0xb2, 0xec, 0x0e, 0x50, 0xaf, 0xf1, 0x13, 0x4d, 0xce, 0x90, 0x72, 0x2c,
+    0x6d, 0x33, 0xd1, 0x8f, 0x0c, 0x52, 0xb0, 0xee, 0x32, 0x6c, 0x8e, 0xd0,
+    0x53, 0x0d, 0xef, 0xb1, 0xf0, 0xae, 0x4c, 0x12, 0x91, 0xcf, 0x2d, 0x73,
+    0xca, 0x94, 0x76, 0x28, 0xab, 0xf5, 0x17, 0x49, 0x08, 0x56, 0xb4, 0xea,
+    0x69, 0x37, 0xd5, 0x8b, 0x57, 0x09, 0xeb, 0xb5, 0x36, 0x68, 0x8a, 0xd4,
+    0x95, 0xcb, 0x29, 0x77, 0xf4, 0xaa, 0x48, 0x16, 0xe9, 0xb7, 0x55, 0x0b,
+    0x88, 0xd6, 0x34, 0x6a, 0x2b, 0x75, 0x97, 0xc9, 0x4a, 0x14, 0xf6, 0xa8,
+    0x74, 0x2a, 0xc8, 0x96, 0x15, 0x4b, 0xa9, 0xf7, 0xb6, 0xe8, 0x0a, 0x54,
+    0xd7, 0x89, 0x6b, 0x35,
+};
+
+//* 系统整帧 CRC16 使用的初始值。
+static const uint16_t k_crc16_init = 0xffffu;
+
+//* CRC16 预计算状态转移表。
+//? 更新路径先右移当前 CRC，再异或由 (current_crc ^ next_byte) 低 8 位选出的表项。
+static const uint16_t k_crc16_tab[256] = {
+    0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf, 0x8c48,
+    0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5, 0xe97e, 0xf8f7, 0x1081, 0x0108,
+    0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e, 0x9cc9, 0x8d40, 0xbfdb,
+    0xae52, 0xdaed, 0xcb64, 0xf9ff, 0xe876, 0x2102, 0x308b, 0x0210, 0x1399,
+    0x6726, 0x76af, 0x4434, 0x55bd, 0xad4a, 0xbcc3, 0x8e58, 0x9fd1, 0xeb6e,
+    0xfae7, 0xc87c, 0xd9f5, 0x3183, 0x200a, 0x1291, 0x0318, 0x77a7, 0x662e,
+    0x54b5, 0x453c, 0xbdcb, 0xac42, 0x9ed9, 0x8f50, 0xfbef, 0xea66, 0xd8fd,
+    0xc974, 0x4204, 0x538d, 0x6116, 0x709f, 0x0420, 0x15a9, 0x2732, 0x36bb,
+    0xce4c, 0xdfc5, 0xed5e, 0xfcd7, 0x8868, 0x99e1, 0xab7a, 0xbaf3, 0x5285,
+    0x430c, 0x7197, 0x601e, 0x14a1, 0x0528, 0x37b3, 0x263a, 0xdecd, 0xcf44,
+    0xfddf, 0xec56, 0x98e9, 0x8960, 0xbbfb, 0xaa72, 0x6306, 0x728f, 0x4014,
+    0x519d, 0x2522, 0x34ab, 0x0630, 0x17b9, 0xef4e, 0xfec7, 0xcc5c, 0xddd5,
+    0xa96a, 0xb8e3, 0x8a78, 0x9bf1, 0x7387, 0x620e, 0x5095, 0x411c, 0x35a3,
+    0x242a, 0x16b1, 0x0738, 0xffcf, 0xee46, 0xdcdd, 0xcd54, 0xb9eb, 0xa862,
+    0x9af9, 0x8b70, 0x8408, 0x9581, 0xa71a, 0xb693, 0xc22c, 0xd3a5, 0xe13e,
+    0xf0b7, 0x0840, 0x19c9, 0x2b52, 0x3adb, 0x4e64, 0x5fed, 0x6d76, 0x7cff,
+    0x9489, 0x8500, 0xb79b, 0xa612, 0xd2ad, 0xc324, 0xf1bf, 0xe036, 0x18c1,
+    0x0948, 0x3bd3, 0x2a5a, 0x5ee5, 0x4f6c, 0x7df7, 0x6c7e, 0xa50a, 0xb483,
+    0x8618, 0x9791, 0xe32e, 0xf2a7, 0xc03c, 0xd1b5, 0x2942, 0x38cb, 0x0a50,
+    0x1bd9, 0x6f66, 0x7eef, 0x4c74, 0x5dfd, 0xb58b, 0xa402, 0x9699, 0x8710,
+    0xf3af, 0xe226, 0xd0bd, 0xc134, 0x39c3, 0x284a, 0x1ad1, 0x0b58, 0x7fe7,
+    0x6e6e, 0x5cf5, 0x4d7c, 0xc60c, 0xd785, 0xe51e, 0xf497, 0x8028, 0x91a1,
+    0xa33a, 0xb2b3, 0x4a44, 0x5bcd, 0x6956, 0x78df, 0x0c60, 0x1de9, 0x2f72,
+    0x3efb, 0xd68d, 0xc704, 0xf59f, 0xe416, 0x90a9, 0x8120, 0xb3bb, 0xa232,
+    0x5ac5, 0x4b4c, 0x79d7, 0x685e, 0x1ce1, 0x0d68, 0x3ff3, 0x2e7a, 0xe70e,
+    0xf687, 0xc41c, 0xd595, 0xa12a, 0xb0a3, 0x8238, 0x93b1, 0x6b46, 0x7acf,
+    0x4854, 0x59dd, 0x2d62, 0x3ceb, 0x0e70, 0x1ff9, 0xf78f, 0xe606, 0xd49d,
+    0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330, 0x7bc7, 0x6a4e, 0x58d5, 0x495c,
+    0x3de3, 0x2c6a, 0x1ef1, 0x0f78,
+};
+
+//* 计算一段连续字节的 CRC8。
+//? ucCRC8 是种子值：新计算传 k_crc8_init，分段续算传上一段的返回值。
+//! 该底层计算函数在 dwLength 非 0 时默认 pchMessage 有效；校验/追加包装函数会先做空指针检查。
+uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
+                           uint8_t ucCRC8)
+{
+  uint8_t ucIndex = 0u;
+
+  //? 每轮消耗 1 字节，并把该字节折叠进当前 CRC 状态。
+  while (dwLength-- != 0u)
+  {
+    ucIndex = ucCRC8 ^ (*pchMessage++);
+    ucCRC8 = k_crc8_tab[ucIndex];
+  }
+  return ucCRC8;
+}
+
+//* 校验缓冲区末尾已保存的 CRC8。
+//? 最后 1 字节被视为接收到的校验值，前面的字节会重新计算后与它比较。
+uint32_t Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
+{
+  uint8_t expected = 0u;
+
+  //! 系统帧头至少要包含有效字段和 1 字节 CRC8。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return FALSE;
+  }
+
+  //? 计算窗口排除末尾已经保存的 CRC8 字节。
+  expected = Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u),
+                                k_crc8_init);
+  return (expected == pchMessage[dwLength - 1u]) ? TRUE : FALSE;
+}
+
+//* 把重新计算得到的 CRC8 写入缓冲区末尾。
+//? 应在所有受 CRC8 保护的帧头字段都填充完成后调用。
+void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
+{
+  //! 不向空指针或长度不足的缓冲区写入。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return;
+  }
+
+  //? 校验字节本身不参与本轮 CRC8 计算。
+  pchMessage[dwLength - 1u] =
+      Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u), k_crc8_init);
+}
+
+//* 计算一段连续字节的 CRC16。
+//? wCRC 是种子值或当前状态：新整帧计算传 k_crc16_init。
+uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
+                             uint16_t wCRC)
+{
+  uint8_t chData = 0u;
+
+  //! 保留旧实现对无效缓冲区返回 0xffffu 的行为，避免影响现有调用方。
+  if (pchMessage == NULL)
+  {
+    return 0xffffu;
+  }
+
+  //? 将每个输入字节折叠到 CRC 低位，再通过查表推进到下一状态。
+  while (dwLength-- != 0u)
+  {
+    chData = *pchMessage++;
+    wCRC = (uint16_t)((wCRC >> 8u) ^
+                      k_crc16_tab[(uint8_t)(wCRC ^ chData)]);
+  }
+  return wCRC;
+}
+
+//* 校验完整帧末尾 2 字节保存的 CRC16。
+//? 裁判系统 CRC16 为小端保存：dwLength - 2 是低字节，dwLength - 1 是高字节。
+uint32_t Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
+{
+  uint16_t expected = 0u;
+
+  //! 完整帧至少要包含受保护数据和 2 字节 CRC16。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return FALSE;
+  }
+
+  //? 只重算受保护的载荷/帧头区域，末尾 CRC16 不参与计算。
+  expected = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
+  return (((expected & 0x00ffu) == pchMessage[dwLength - 2u]) &&
+          (((expected >> 8u) & 0x00ffu) == pchMessage[dwLength - 1u]))
+             ? TRUE
+             : FALSE;
+}
+
+//* 把 CRC16 追加到完整帧缓冲区末尾 2 字节。
+//? 应在除 CRC16 尾部以外的所有帧字段都填充完成后调用。
+void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
+{
+  uint16_t wCRC = 0u;
+
+  //! 不向空指针或长度不足的帧缓冲区写入。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return;
+  }
+
+  //? 按系统线缆/帧格式保存：低字节在前，高字节在后。
+  wCRC = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
+  pchMessage[dwLength - 2u] = (uint8_t)(wCRC & 0x00ffu);
+  pchMessage[dwLength - 1u] = (uint8_t)((wCRC >> 8u) & 0x00ffu);
+}
+
+
+```
+
+
+protocol_frame.c
+
+```c
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crc_ref.h"
+
+#define FRAME_START_BYTE 0xA5u /* 固定帧头，用于接收端寻找一帧的开始。 */
+#define FRAME_CRC16_SIZE 2u    /* CRC16 占两个线上字节。 */
+
+/*
+ * 线上帧格式（所有偏移量均相对于 protocol_frame_t 起始地址）：
+ *
+ *   偏移 0       start              帧头，1 字节
+ *   偏移 1       type               所属分类，1 字节
+ *   偏移 2..3    payload_length     payload 长度，2 字节，小端序
+ *   偏移 4..7    timestamp          时间戳，4 字节，小端序
+ *   偏移 8       header_crc8        帧头 CRC8，1 字节
+ *   偏移 9..     payload            可变长度的业务数据
+ *   最后 2 字节  crc16              整帧 CRC16，低字节在前
+ *
+ * payload 是协议中的可变长度区域。柔性数组成员必须是结构体的最后一个成员，
+ * 因此 CRC16 尾部通过同一次分配的额外空间放在 payload 后面。多字节字段使用
+ * 字节数组保存，再显式按协议字节序读写，避免结构体填充和主机字节序影响线上格式。
+ */
+typedef struct {
+    uint8_t start;
+    uint8_t type;
+    uint8_t payload_length[2];
+    uint8_t timestamp[4];
+    uint8_t header_crc8;
+    uint8_t payload[];
+} protocol_frame_t;
+
+enum {
+    FRAME_START_OFFSET = offsetof(protocol_frame_t, start), // 帧头偏移
+    FRAME_TYPE_OFFSET = offsetof(protocol_frame_t, type), // 帧类型偏移
+    FRAME_PAYLOAD_LENGTH_OFFSET = offsetof(protocol_frame_t, payload_length), // 帧负载长度偏移
+    FRAME_TIMESTAMP_OFFSET = offsetof(protocol_frame_t, timestamp), // 时间戳偏移
+    FRAME_HEADER_CRC8_OFFSET = offsetof(protocol_frame_t, header_crc8), // 帧头 CRC8 偏移
+    FRAME_PAYLOAD_OFFSET = offsetof(protocol_frame_t, payload), // 可变长度数据的偏移
+    FRAME_HEADER_SIZE = offsetof(protocol_frame_t, payload) // 固定线上帧头长度
+};
+
+/*
+ * 按指定字节序把 16 位整数写入线上缓冲区。
+ *
+ * big_endian == true：大端序，高字节在前；
+ * big_endian == false：小端序，低字节在前。
+ * C 语言没有可省略的默认参数，因此 false 是调用者应使用的默认选择，
+ * 必须在调用处显式传入。当前协议的调用点统一传入 false，使用小端序。
+ */
+static void write_u16(uint8_t *destination, uint16_t value,
+                         bool big_endian) {
+    if (big_endian) {
+        destination[0] = (uint8_t)(value >> 8u);
+        destination[1] = (uint8_t)value;
+    } else {
+        destination[0] = (uint8_t)value;
+        destination[1] = (uint8_t)(value >> 8u);
+    }
+}
+
+/* 按 big_endian 选择的字节序把 32 位整数写入线上缓冲区。 */
+static void write_u32(uint8_t *destination, uint32_t value,
+                         bool big_endian) {
+    if (big_endian) {
+        destination[0] = (uint8_t)(value >> 24u);
+        destination[1] = (uint8_t)(value >> 16u);
+        destination[2] = (uint8_t)(value >> 8u);
+        destination[3] = (uint8_t)value;
+    } else {
+        destination[0] = (uint8_t)value;
+        destination[1] = (uint8_t)(value >> 8u);
+        destination[2] = (uint8_t)(value >> 16u);
+        destination[3] = (uint8_t)(value >> 24u);
+    }
+}
+
+/* 按 big_endian 选择的字节序从线上缓冲区读取 16 位整数。 */
+static uint16_t read_u16(const uint8_t *source, bool big_endian) {
+    if (big_endian) {
+        return (uint16_t)(((uint16_t)source[0] << 8u) |
+                          (uint16_t)source[1]);
+    }
+
+    return (uint16_t)((uint16_t)source[0] |
+                      ((uint16_t)source[1] << 8u));
+}
+
+/* 按 big_endian 选择的字节序从线上缓冲区读取 32 位整数。 */
+static uint32_t read_u32(const uint8_t *source, bool big_endian) {
+    if (big_endian) {
+        return ((uint32_t)source[0] << 24u) |
+               ((uint32_t)source[1] << 16u) |
+               ((uint32_t)source[2] << 8u) |
+               (uint32_t)source[3];
+    }
+
+    return (uint32_t)source[0] |
+           ((uint32_t)source[1] << 8u) |
+           ((uint32_t)source[2] << 16u) |
+           ((uint32_t)source[3] << 24u);
+}
+
+/*
+ * 组装一帧完整的线上数据。
+ *
+ * 函数先检查长度和指针，再分配空间；之后按协议序列化字段、复制 payload，
+ * 最后计算 CRC8 和 CRC16。这样 CRC 覆盖的是最终真正要发送的字节。
+ */
+static int data_process(uint8_t type, uint32_t timestamp,
+                        const uint8_t *payload, size_t payload_size,
+                        protocol_frame_t **frame_out,
+                        uint32_t *frame_size_out) {
+    size_t calculated_frame_size;//计算的帧大小
+    protocol_frame_t *frame;//分配的帧缓冲区
+
+    /* 输出参数无效时不能写回结果。 */
+    if ((frame_out == NULL) || (frame_size_out == NULL)) {
+        return FALSE;
+    }
+
+    *frame_out = NULL;
+    *frame_size_out = 0u;
+
+    /* payload_length 只有 16 位，超出后强制转换会发生截断。 */
+    if (payload_size > UINT16_MAX) {
+        fputs("Payload is too large for the 16-bit length field.\n", stderr);
+        return FALSE;
+    }
+    /* 只有空 payload 才允许 payload 指针为 NULL。 */
+    if ((payload == NULL) && (payload_size != 0u)) {
+        fputs("Payload pointer is NULL for a non-empty payload.\n", stderr);
+        return FALSE;
+    }
+    /* 先检查加法，再计算总长度，防止 size_t 溢出。 */
+    if (payload_size > SIZE_MAX - sizeof(protocol_frame_t) - FRAME_CRC16_SIZE) {
+        fputs("Frame size calculation overflowed size_t.\n", stderr);
+        return FALSE;
+    }
+
+    calculated_frame_size =
+        sizeof(protocol_frame_t) + payload_size + FRAME_CRC16_SIZE;
+    /* payload_size 已限制为 uint16_t，故完整帧最大为 65546 字节，可安全转为 uint32_t。 */
+
+    frame = calloc(1u, calculated_frame_size);
+    if (frame == NULL) {
+        fputs("Failed to allocate protocol frame.\n", stderr);
+        return FALSE;
+    }
+
+    /* 写入固定字段：多字节普通字段统一使用小端序。 */
+    frame->start = FRAME_START_BYTE;
+    frame->type = type;
+    /* 协议规定 payload_length 使用小端序，因此这里明确传入 false。 */
+    write_u16(frame->payload_length, (uint16_t)payload_size, false);
+    /* 协议规定 timestamp 使用小端序，因此这里明确传入 false。 */
+    write_u32(frame->timestamp, timestamp, false);
+    frame->header_crc8 = 0u;
+
+    /* payload 是可变长度区域，紧接在固定帧头之后。 */
+    if (payload_size != 0u) {
+        memcpy(frame->payload, payload, payload_size);
+    }
+
+    /* CRC8 覆盖前 8 个帧头字节，并把结果写入偏移 8。 */
+    Append_CRC8_Check_Sum((uint8_t *)frame, (uint16_t)FRAME_HEADER_SIZE);
+    /* CRC16 计算覆盖帧头和 payload；计算结果写入帧尾预留的两个 CRC16 字节。 */
+    Append_CRC16_Check_Sum((uint8_t *)frame, (uint32_t)calculated_frame_size);
+
+    *frame_out = frame;
+    *frame_size_out = (uint32_t)calculated_frame_size;
+    return TRUE;
+}
+
+static void print_layout(void) {
+    printf("start offset:          %zu\n", (size_t)FRAME_START_OFFSET);
+    printf("type offset:           %zu\n", (size_t)FRAME_TYPE_OFFSET);
+    printf("payload_length offset: %zu\n", (size_t)FRAME_PAYLOAD_LENGTH_OFFSET);
+    printf("timestamp offset:      %zu\n", (size_t)FRAME_TIMESTAMP_OFFSET);
+    printf("header_crc8 offset:    %zu\n", (size_t)FRAME_HEADER_CRC8_OFFSET);
+    printf("payload offset:        %zu\n", (size_t)FRAME_PAYLOAD_OFFSET);
+}
+
+int main(void) {
+    uint8_t crc_test_vector[] = "123456789";
+    /* 示例 payload；实际项目中可替换为待发送的业务数据。 */
+    const uint8_t sample_payload[] = {0x10u, 0x20u, 0x30u, 0x40u};
+    const size_t payload_size = sizeof(sample_payload);
+    protocol_frame_t *frame = NULL;
+    uint32_t frame_size = 0u;
+    const uint8_t *crc16;
+
+    /* type=0x01 表示一个示例业务分类，时间戳固定为 0x12345678。 */
+    if (data_process(0x01u, 0x12345678u, sample_payload,
+                     payload_size, &frame, &frame_size) != TRUE) {
+        return EXIT_FAILURE;
+    }
+
+    /* CRC16 位于 payload 后面，因此它的起始偏移随 payload 长度变化。 */
+    crc16 = &frame->payload[payload_size];
+
+    /* 固定测试向量锁定当前 CRC 参数，防止查找表或初值被误改。 */
+    if ((Get_CRC8_Check_Sum(crc_test_vector, 9u, 0xffu) != 0x0bu) ||
+        (Get_CRC16_Check_Sum(crc_test_vector, 9u, 0xffffu) != 0x6f91u)) {
+        fputs("CRC test vector check failed.\n", stderr);
+        free(frame);
+        return EXIT_FAILURE;
+    }
+
+    print_layout();
+    printf("CRC test vector:       passed (CRC-8=0x0B, CRC-16=0x6F91)\n");
+    printf("crc16 offset:          %u\n",
+           (unsigned int)(crc16 - (const uint8_t *)frame));
+    printf("total frame size:      %u bytes\n", (unsigned int)frame_size);
+    /* 通过解码函数读取线上字段，验证字节序与数值均正确。 */
+    printf("payload length:        %u\n",
+           (unsigned int)read_u16(frame->payload_length, false));
+    printf("timestamp:             0x%08X\n",
+           (unsigned int)read_u32(frame->timestamp, false));
+    printf("timestamp wire bytes:  %02X %02X %02X %02X\n",
+           (unsigned int)frame->timestamp[0],
+           (unsigned int)frame->timestamp[1],
+           (unsigned int)frame->timestamp[2],
+           (unsigned int)frame->timestamp[3]);
+    printf("crc8 check:            %s\n",
+           Verify_CRC8_Check_Sum((uint8_t *)frame,
+                                 (uint16_t)FRAME_HEADER_SIZE) == TRUE
+               ? "passed"
+               : "failed");
+    printf("crc16 check:           %s\n",
+           Verify_CRC16_Check_Sum((uint8_t *)frame, frame_size) == TRUE
+               ? "passed"
+               : "failed");
+
+    free(frame);
+    return EXIT_SUCCESS;
+}
+
+
+```
+
+:::
+
+把三个文件放在同一目录后编译运行：
+
+```bash
+gcc -std=c11 -Wall -Wextra -Wpedantic protocol_frame.c crc_ref.c -o protocol_frame && ./protocol_frame
+```
+
+这组测试数据的输出如下：
+
+```text
+start offset:          0
+type offset:           1
+payload_length offset: 2
+timestamp offset:      4
+header_crc8 offset:    8
+payload offset:        9
+CRC test vector:       passed (CRC-8=0x0B, CRC-16=0x6F91)
+crc16 offset:          13
+total frame size:      15 bytes
+payload length:        4
+timestamp:             0x12345678
+timestamp wire bytes:  78 56 34 12
+crc8 check:            passed
+crc16 check:           passed
+```
+
+这里没有把 `uint16_t` 或 `uint32_t` 直接塞进线上结构体，而是把多字节字段保存成字节数组，再由 `write_u16`、`write_u32` 明确序列化；当前协议调用它们时传入 `false`，固定使用小端序。这样结构体填充和主机字节序都不会偷偷改变协议格式，接收端也能用对应的读取函数还原数值。
+
+固定线上帧头长度取 `offsetof(protocol_frame_t, payload)`，而不是把 `sizeof(protocol_frame_t)` 当成协议长度。柔性数组成员本身不计入 `sizeof`，但标准允许结构体在末尾保留额外填充；用成员偏移计算线上头长，才能准确找到 payload 真正开始的位置。分配内存时仍使用 `sizeof(protocol_frame_t)`，这样连同可能的尾部填充也有足够空间；CRC16 则放在同一次分配中、紧跟 payload 的两个额外字节里。
+
+> ⚠️ **踩坑预警**
+> CRC 不只是一个“CRC16”名字：多项式、初值、输入/输出反射、最终异或值和线上字节序共同决定结果。本例的 CRC-8 使用多项式 `0x31`、初值 `0xFF`、反射输入/输出、最终异或值 `0x00`；CRC-16 使用多项式 `0x1021`、初值 `0xFFFF`、反射输入/输出、最终异或值 `0x0000`，并按小端写入帧尾。`"123456789"` 的固定测试结果分别为 `0x0B` 和 `0x6F91`，用于防止示例内部参数被误改；接入真实设备时，仍必须同协议文档或设备给出的测试帧逐项核对，不能只看位数相同就直接复用。
+
+:::
+
 ## 参考资源
 
 - [C struct - cppreference](https://en.cppreference.com/w/c/language/struct)
-- [C11 alignas/alignof - cppreference](https://en.cppreference.com/w/c/language/alignment)
+- [C11 alignas/alignof - cppreference](https://en.cppreference.com/w/c/language/_Alignas)
 - [offsetof - cppreference](https://en.cppreference.com/w/c/types/offsetof)
 - [Flexible array members - cppreference](https://en.cppreference.com/w/c/language/struct)

--- a/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
+++ b/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
@@ -8,7 +8,7 @@ order: 16
 platform: host
 prerequisites:
 - restrict、不完整类型与结构体指针
-reading_time_minutes: 20
+reading_time_minutes: 64
 tags:
 - host
 - cpp-modern

--- a/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
+++ b/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
@@ -4,13 +4,14 @@ cpp_standard:
 - 11
 - 14
 - 17
+- 20
 description: 掌握联合体、枚举、位域与 typedef 的使用，理解类型双关、硬件寄存器映射等技巧，对比 C++ 的类型安全替代方案
 difficulty: beginner
 order: 17
 platform: host
 prerequisites:
 - 12 结构体与内存对齐
-reading_time_minutes: 11
+reading_time_minutes: 22
 tags:
 - host
 - cpp-modern
@@ -72,7 +73,7 @@ int main(void) {
 sizeof(IntUnion) = 4
 ```
 
-`IntUnion` 的大小是 4 字节——由最大的成员 `uint32_t` 决定。`u8`、`u16`、`u32` 三个成员的起始地址完全相同，写入其中一个就会覆盖其他的。
+在当前 GCC x86_64 环境中，`IntUnion` 的大小是 4 字节。`u8`、`u16`、`u32` 三个成员的起始地址完全相同；写入某个成员后，其他成员看到的也是这块重叠存储中的字节，而不是三份彼此独立的数据。
 
 > ⚠️ **踩坑预警**：联合体在同一时刻只有**一个**成员是有效的。写入一个成员后再读取另一个成员，在 C 标准中属于未定义行为（除了类型双关的例外）。你必须自己记住当前哪个成员是活跃的，编译器不会帮你检查。
 
@@ -185,7 +186,7 @@ Color c = 42;          // 合法！但 42 不是任何枚举值
 int x = kColorRed;     // 合法！隐式转为 int
 ```
 
-这种宽松在 C 语言看来是"灵活性"，但从类型安全的角度看就是灾难——编译器完全没办法帮你检查"这个值是不是合法的枚举值"。这也是 C++ 引入 `enum class` 的根本原因。
+这种宽松在 C 语言看来是"灵活性"，但从类型安全的角度看就是灾难——编译器完全没办法帮你检查"这个值是不是合法的枚举值"。这也是 C++11 引入 `enum class` 的根本原因。
 
 ## 第三步——用位域按位分配内存
 
@@ -370,6 +371,120 @@ int main(void) {
 }
 ```
 
+::: details 参考答案
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef union {
+    float f;
+    uint32_t u;
+} FloatBits;
+
+//float的IEEE 754 浮点数字节规则
+//1 位符号 |  8 位指数                  |  23 位尾数
+//正还是负 | 决定能表示多大、多小（范围） | 决定有多少位有效数字（精度）
+void print_float_bits(float f)
+{
+    FloatBits data;
+    data.f = f;
+
+    uint32_t sign = (data.u >> 31) & 0x1;
+    uint32_t exponent = (data.u >> 23) & 0xff;
+    uint32_t fraction = data.u & 0x7fffff;
+
+    printf("float = %f\n", f);
+
+    printf("bits     = ");
+    for (int i = 31; i >= 0; --i)
+    {
+        printf("%u", (unsigned int)((data.u >> i) & 1u));
+        if (i == 31 || i == 23)
+        {
+            printf(" ");
+        }
+    }
+    printf("\n");
+
+    printf("1 位符号     = %u\n", (unsigned int)sign);
+    printf("8 位指数 = ");
+    for (int i = 7; i >= 0; --i)
+    {
+        printf("%u", (unsigned int)((exponent >> i) & 1u));
+    }
+    printf("\n");
+
+    printf("23 位尾数 = ");
+    for (int i = 22; i >= 0; --i)
+    {
+        printf("%u", (unsigned int)((fraction >> i) & 1u));
+    }
+    printf("\n");
+}
+
+int main(void)
+{
+    char input[32] = {0};
+    char trailing_character;
+    float value = 0.0f;
+
+    printf("请输入 float：");
+    fflush(stdout);
+
+    if (fgets(input, sizeof(input), stdin) == NULL)
+    {
+        fputs("读取输入失败。\n", stderr);
+        return 1;
+    }
+
+    /* 缓冲区未读到换行时，确认是否还有未读取的字符，避免静默截断。 */
+    if (strchr(input, '\n') == NULL)
+    {
+        //读取输入的第32个字符
+        int next_character = getchar();
+       
+        if (next_character != '\n' && next_character != EOF)
+        {
+            while (next_character != '\n' && next_character != EOF)
+            {
+                next_character = getchar();
+            }
+            fputs("输入过长。\n", stderr);
+            return 1;
+        }
+    }
+
+    /* 第二个转换项用于拒绝数字后仍含有非空白字符的输入。 */
+    if (sscanf(input, "%f %c", &value, &trailing_character) != 1)
+    {
+        printf("输入无效！\n");
+        return 1;
+    }
+
+    print_float_bits(value);
+    return 0;
+}
+
+```
+
+在支持 IEEE 754 binary32 的 GCC x86_64 环境中，输入 `-3.14` 的结果如下：
+
+```text
+请输入 float：-3.14
+float = -3.140000
+bits     = 1 10000000 10010001111010111000011
+1 位符号     = 1
+8 位指数 = 10000000
+23 位尾数 = 10010001111010111000011
+```
+
+> ⚠️ **踩坑预警**
+> `fgets` 对 `char input[32]` 最多读取 31 个字符，并在末尾追加 `\0`。当输入行超过 31 个字符时，函数仍会返回成功，但换行符和剩余内容还留在输入流中；如果不检查 `next_character` 是否为 `\n` 或 `EOF`，即使输入过长仍会判断为为完整读取。
+
+:::
+
 ### 练习 2：32 位硬件控制寄存器
 
 **难度：基础** · 位域加 union 映射寄存器
@@ -404,6 +519,110 @@ int main(void) {
 }
 ```
 
+::: details 参考答案
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+
+// 位分配：
+//   bit 0:     enable（1 位）
+//   bit 1:     interrupt_enable（1 位）
+//   bit 2:     dma_enable（1 位）
+//   bit 5:3    mode（3 位）
+//   bit 9:6    speed（4 位）
+//   bit 31:10  reserved（22 位）
+typedef union {
+    struct {
+        uint32_t enable : 1;
+        uint32_t interrupt_enable : 1;
+        uint32_t dma_enable : 1;
+        uint32_t mode : 3;
+        uint32_t speed : 4;
+        uint32_t reserved : 22;
+    } bits;
+    uint32_t value;
+} ControlRegister;
+
+void print_register(ControlRegister reg)
+{
+    printf("Register = 0x%08X\n", (unsigned int)reg.value);
+    printf("  enable: %u\n", (unsigned int)reg.bits.enable);
+    printf("  interrupt_enable: %u\n", (unsigned int)reg.bits.interrupt_enable);
+    printf("  dma_enable: %u\n", (unsigned int)reg.bits.dma_enable);
+    printf("  mode: %u\n", (unsigned int)reg.bits.mode);
+    printf("  speed: %u\n", (unsigned int)reg.bits.speed);
+}
+
+void set_mode(ControlRegister *reg, uint32_t mode)
+{
+    if (reg == NULL) {
+        return;
+    }
+
+    // mode 仅占 3 位，因此只保留参数的低 3 位。
+    reg->bits.mode = mode & 0x7U;
+}
+
+int main(void)
+{
+    ControlRegister reg = {0};
+
+    reg.bits.enable = 1U;
+    reg.bits.interrupt_enable = 1U;
+    reg.bits.dma_enable = 0U;
+    reg.bits.speed = 10U;
+    set_mode(&reg, 5U);
+
+    print_register(reg);
+    // 9:1001(取低 3 位)
+    set_mode(&reg, 9U); // 9 被截断为 3 位数值 1。
+    print_register(reg);
+
+    return 0;
+}
+```
+
+在本例的 GCC x86_64 布局中，声明顺序从低位向高位分配；从 32 位整数的高位到低位看，布局如下：
+
+```text
+位编号  31                  10 9       6 5       3   2   1   0
+       +-----------------------+---------+-------+---+---+---+
+字段   |     reserved (22)     | speed 4 | mode 3| D | I | E |
+       +-----------------------+---------+-------+---+---+---+
+位范围          [31:10]            [9:6]    [5:3]  2    1   0
+```
+
+- `E` = `enable`，占 bit 0
+- `I` = `interrupt_enable`，占 bit 1
+- `D` = `dma_enable`，占 bit 2
+
+`value` 与 `bits` 共用同一段 32 位存储，因此可用 `value` 观察这些位的整体值。位域的实际分配方向、对齐和填充由实现定义；上图只描述这一示例已实测的 GCC x86_64 布局，不能直接当作跨编译器或跨目标平台的寄存器协议。
+
+```bash
+gcc -std=c11 -Wall -Wextra -Wpedantic bitfield_register.c -o bitfield_register && ./bitfield_register
+```
+
+在 WSL Ubuntu 24.04（GCC 13.3，x86_64）中运行：
+
+```text
+Register = 0x000002AB
+  enable: 1
+  interrupt_enable: 1
+  dma_enable: 0
+  mode: 5
+  speed: 10
+Register = 0x0000028B
+  enable: 1
+  interrupt_enable: 1
+  dma_enable: 0
+  mode: 1
+  speed: 10
+```
+
+
+:::
+
 ### 练习 3：简单的 tagged union
 
 **难度：基础** · enum 加 union 加 tag 检查
@@ -427,3 +646,191 @@ int main(void) {
     return 0;
 }
 ```
+
+::: details 参考答案
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+
+/* 用于标识联合体中当前有效成员的类型标签。 */
+typedef enum {
+    TAG_INT,
+    TAG_FLOAT,
+    TAG_STRING
+} ValueTag;
+
+/*
+ * 联合体的所有成员共用同一块存储空间。
+ * 读取时必须根据 ValueTag 选择与最后一次写入相对应的成员。
+ */
+typedef union {
+    int int_value;
+    float float_value;
+    const char *string_value;
+} ValueData;
+
+/* 将类型标签与实际数据绑定，构成一个可存放多种类型的值。 */
+typedef struct {
+    ValueTag tag;
+    ValueData data;
+} TaggedValue;
+
+/* 构造一个保存 int 的带标签值。 */
+TaggedValue make_int(int value)
+{
+    TaggedValue result = { TAG_INT, { .int_value = value } };
+    return result;
+}
+
+/* 构造一个保存 float 的带标签值。 */
+TaggedValue make_float(float value)
+{
+    TaggedValue result = { TAG_FLOAT, { .float_value = value } };
+    return result;
+}
+
+/*
+ * 构造一个保存字符串指针的带标签值。
+ * 该函数不会复制字符串，调用方必须保证字符串在使用期间仍然有效。
+ */
+TaggedValue make_string(const char *value)
+{
+    TaggedValue result = { TAG_STRING, { .string_value = value } };
+    return result;
+}
+
+/* 根据类型标签，以对应的格式输出当前有效成员。 */
+void print_tagged_value(const TaggedValue *value)
+{
+    /* 防止调用方传入空指针后解引用。 */
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return;
+    }
+
+    switch (value->tag) {
+    case TAG_INT:
+        printf("int: %d\n", value->data.int_value);
+        break;
+    case TAG_FLOAT:
+        printf("float: %.2f\n", value->data.float_value);
+        break;
+    case TAG_STRING:
+        /* %s 的实参不能是空指针，避免未定义行为。 */
+        if (value->data.string_value == NULL) {
+            fprintf(stderr, "Error: string value is NULL.\n");
+            return;
+        }
+        printf("string: %s\n", value->data.string_value);
+        break;
+    default:
+        /* 标签被破坏或未按约定初始化时，禁止读取联合体成员。 */
+        fprintf(stderr, "Error: unknown value tag.\n");
+        break;
+    }
+}
+
+/* 仅当值实际保存 int 时返回其内容，否则返回 0 并报告错误。 */
+int get_as_int(const TaggedValue *value)
+{
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return 0;
+    }
+
+    if (value->tag != TAG_INT) {
+        fprintf(stderr, "Error: value is not an int.\n");
+        return 0;
+    }
+
+    return value->data.int_value;
+}
+
+/* 仅当值实际保存 float 时返回其内容，否则返回 0.0f 并报告错误。 */
+float get_as_float(const TaggedValue *value)
+{
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return 0.0f;
+    }
+
+    if (value->tag != TAG_FLOAT) {
+        fprintf(stderr, "Error: value is not a float.\n");
+        return 0.0f;
+    }
+
+    return value->data.float_value;
+}
+
+/* 仅当值实际保存字符串指针时返回该指针，否则返回 NULL 并报告错误。 */
+const char *get_as_string(const TaggedValue *value)
+{
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return NULL;
+    }
+
+    if (value->tag != TAG_STRING) {
+        fprintf(stderr, "Error: value is not a string.\n");
+        return NULL;
+    }
+
+    return value->data.string_value;
+}
+
+int main(void)
+{
+    /* 分别创建三种不同类型的带标签值。 */
+    TaggedValue int_value = make_int(42);
+    TaggedValue float_value = make_float(3.14f);
+    TaggedValue string_value = make_string("Hello, tagged union!");
+    const char *text;
+
+    /* 输出时由类型标签决定应读取联合体的哪个成员。 */
+    print_tagged_value(&int_value);
+    print_tagged_value(&float_value);
+    print_tagged_value(&string_value);
+
+    /* 通过类型匹配的访问函数读取数据。 */
+    printf("get_as_int: %d\n", get_as_int(&int_value));
+    printf("get_as_float: %.2f\n", get_as_float(&float_value));
+    text = get_as_string(&string_value);
+    if (text != NULL) {
+        printf("get_as_string: %s\n", text);
+    }
+
+    /* 以下两次调用用于演示类型不匹配时的错误处理。 */
+    (void)get_as_float(&int_value);
+    (void)get_as_string(&float_value);
+
+    return 0;
+}
+
+```
+
+```bash
+gcc -std=c11 -Wall -Wextra -Wpedantic tagged_union.c -o tagged_union && ./tagged_union
+```
+
+运行结果：
+
+```text
+int: 42
+float: 3.14
+string: Hello, tagged union!
+get_as_int: 42
+get_as_float: 3.14
+get_as_string: Hello, tagged union!
+Error: value is not a float.
+Error: value is not a string.
+```
+
+`TaggedValue` 的 `tag` 和 `data` 必须一起维护：写入 `data.float_value` 后，只有 `tag == kValueTagFloat` 时才可以读取它。`make_string` 只保存指针，不复制字符串，因此调用方必须保证字符串的存储期覆盖整个使用过程；这里用 `bool` 加输出参数表示访问结果，也避免把合法的 `0`、`0.0f` 或 `NULL` 与错误混为一谈。
+
+:::
+
+## 参考资源
+
+- [cppreference：C union](https://en.cppreference.com/w/c/language/union)、[C enumeration](https://en.cppreference.com/w/c/language/enum)、[C bit-field](https://en.cppreference.com/w/c/language/bit_field)：C 语言规则与实现差异速查。
+- [cppreference：`std::variant`](https://en.cppreference.com/w/cpp/utility/variant)、[`std::bitset`](https://en.cppreference.com/w/cpp/utility/bitset)、[`std::bit_cast`](https://en.cppreference.com/w/cpp/numeric/bit_cast)：C++11/17/20 对应工具。

--- a/documents/vol1-fundamentals/c_tutorials/14-dynamic-memory.md
+++ b/documents/vol1-fundamentals/c_tutorials/14-dynamic-memory.md
@@ -278,6 +278,57 @@ void intvec_free(IntVec* v) {
 
 关键是 `realloc` 的返回值先存到 `new_data`、判断成功后再赋给 `v->data`。要是直接写 `v->data = realloc(v->data, ...)`，一旦失败原来的 `v->data` 就被 NULL 覆盖，那块内存再也找不回来，就是泄漏。
 
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+
+/* 把上面的 intvec_init / intvec_push / intvec_free 粘贴到此处 */
+
+int main(void) {
+    IntVec v;
+    intvec_init(&v);
+    printf("初始容量 = %zu\n", v.capacity);
+
+    for (int i = 0; i < 10; ++i) {
+        intvec_push(&v, i * 10);
+        printf("push %d -> size=%zu cap=%zu\n", i * 10, v.size, v.capacity);
+    }
+
+    printf("数组内容: ");
+    for (int i = 0; i < (int)v.size; ++i) printf("%d ", v.data[i]);
+    printf("\n");
+
+    intvec_free(&v);
+    printf("释放后 data = %p\n", (void*)v.data);
+    return 0;
+}
+```
+
+```bash
+gcc -std=c11 -Wall -Wextra intvec_test.c -o intvec_test && ./intvec_test
+```
+
+运行结果：
+
+```text
+初始容量 = 4
+push 0 -> size=1 cap=4
+push 10 -> size=2 cap=4
+push 20 -> size=3 cap=4
+push 30 -> size=4 cap=4
+push 40 -> size=5 cap=8
+push 50 -> size=6 cap=8
+push 60 -> size=7 cap=8
+push 70 -> size=8 cap=8
+push 80 -> size=9 cap=16
+push 90 -> size=10 cap=16
+数组内容: 0 10 20 30 40 50 60 70 80 90 
+释放后 data = (nil)
+```
+
+可以看到 `size` 到 5 时容量从 4 翻倍到 8，再到 8 成 16；`realloc` 扩容后旧元素被无损保留。`intvec_free` 把 `data` 置为 NULL，之后误用会立刻崩溃而不是静默读垃圾。
+
 :::
 
 ### 练习 2：内存错误诊断
@@ -336,6 +387,228 @@ void        pool_free(MemoryPool* pool, void* block);
 void        pool_destroy(MemoryPool* pool);
 ```
 
+::: details 参考答案
+
+```c
+#include <stddef.h>
+#include <stdio.h>
+
+/* 单个内存块可容纳的最大字节数。 */
+#define MEMORY_POOL_MAX_BLOCK_SIZE 64U
+/* 单个内存池可管理的最大内存块数量。 */
+#define MEMORY_POOL_MAX_BLOCK_COUNT 16U
+/* 程序可同时创建的内存池实例最大数量。 */
+#define MEMORY_POOL_MAX_INSTANCES 2U
+
+/* 每个内存块的起始地址都按 max_align_t 对齐。 */
+//max_align_t是对齐要求最严格的基础 C 类型，以此为基准可以适应不同的数据类型
+typedef union {
+    max_align_t alignment;//用于强制整个内存块按最严格的基础类型对齐
+    unsigned char bytes[MEMORY_POOL_MAX_BLOCK_SIZE];//以字节数组形式存储的实际内存数据
+} PoolBlock;
+
+typedef struct  {
+    PoolBlock blocks[MEMORY_POOL_MAX_BLOCK_COUNT];//内存块数组，实际存放数据的内存槽位
+    unsigned char in_use[MEMORY_POOL_MAX_BLOCK_COUNT];//每个内存块的占用标记数组，非 0 表示已分配
+    size_t block_size;//每个内存块的字节大小（由 pool_create 指定）
+    size_t block_count;//实际使用的内存块数量（由 pool_create 指定）
+    int active;//内存池实例是否已被创建并投入使用（非 0 表示有效）
+}MemoryPool;
+
+/* 使用静态实例代替运行时堆内存分配。 */
+static MemoryPool memory_pools[MEMORY_POOL_MAX_INSTANCES];
+
+/* 判断内存池指针是否指向本模块管理的静态内存池实例。 */
+static int pool_is_managed(const MemoryPool *pool)
+{
+    size_t i;
+
+    for (i = 0U; i < MEMORY_POOL_MAX_INSTANCES; ++i) {
+        if (pool == &memory_pools[i]) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* 查找内存块在指定内存池中的下标；找到时将下标写入 index。 */
+static int pool_block_index(const MemoryPool *pool, const void *block,
+                            size_t *index)
+{
+    size_t i;
+
+    if (pool == NULL || block == NULL || index == NULL) {
+        return 0;
+    }
+
+    for (i = 0U; i < pool->block_count; ++i) {
+        if (block == (const void *)pool->blocks[i].bytes) {
+            *index = i;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * 创建内存池。
+ * block_size 为每个内存块的字节数，block_count 为内存块数量。
+ * 创建成功返回内存池指针；参数超出上限或无空闲实例时返回 NULL。
+ */
+MemoryPool *pool_create(size_t block_size, size_t block_count)
+{
+    MemoryPool *pool;
+    size_t i;
+
+    if (block_size == 0U || block_size > MEMORY_POOL_MAX_BLOCK_SIZE ||
+        block_count == 0U || block_count > MEMORY_POOL_MAX_BLOCK_COUNT) {
+        return NULL;
+    }
+
+    for (i = 0U; i < MEMORY_POOL_MAX_INSTANCES; ++i) {
+        pool = &memory_pools[i];
+        if (!pool->active) {
+            size_t block_index;
+
+            pool->block_size = block_size;
+            pool->block_count = block_count;
+            pool->active = 1;
+            for (block_index = 0U; block_index < block_count; ++block_index) {
+                pool->in_use[block_index] = 0U;
+            }
+            return pool;
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * 从内存池中分配一个空闲内存块。
+ * 分配成功返回内存块首地址；内存池无效或已满时返回 NULL。
+ */
+void *pool_alloc(MemoryPool *pool)
+{
+    size_t i;
+
+    if (!pool_is_managed(pool) || !pool->active) {
+        return NULL;
+    }
+
+    for (i = 0U; i < pool->block_count; ++i) {
+        if (pool->in_use[i] == 0U) {
+            pool->in_use[i] = 1U;
+            return pool->blocks[i].bytes;
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * 释放由 pool_alloc 从指定内存池分配的内存块。
+ * pool 或 block 无效、block 不属于该内存池或已释放时，函数直接返回。
+ */
+void pool_free(MemoryPool *pool, void *block)
+{
+    size_t index;
+
+    if (!pool_is_managed(pool) || !pool->active ||
+        !pool_block_index(pool, block, &index) || pool->in_use[index] == 0U) {
+        return;
+    }
+
+    pool->in_use[index] = 0U;
+}
+
+/*
+ * 销毁内存池并将其静态实例标记为空闲。
+ * 内存池无效或已销毁时，函数直接返回。
+ */
+void pool_destroy(MemoryPool *pool)
+{
+    size_t i;
+
+    if (!pool_is_managed(pool) || !pool->active) {
+        return;
+    }
+
+    for (i = 0U; i < pool->block_count; ++i) {
+        pool->in_use[i] = 0U;
+    }
+    pool->block_size = 0U;
+    pool->block_count = 0U;
+    pool->active = 0;
+}
+
+int main(void)
+{
+    enum { BLOCK_COUNT = 4 };
+    MemoryPool *pool;
+    int *values[BLOCK_COUNT];
+    int *reused_value;
+    size_t i;
+
+    pool = pool_create(sizeof(int), BLOCK_COUNT);
+    if (pool == NULL) {
+        fputs("内存池创建失败\n", stderr);
+        return 1;
+    }
+
+    for (i = 0U; i < BLOCK_COUNT; ++i) {
+        values[i] = (int *)pool_alloc(pool);
+        if (values[i] == NULL) {
+            fputs("内存池分配失败\n", stderr);
+            pool_destroy(pool);
+            return 1;
+        }
+        *values[i] = (int)(i + 1U) * 10;
+    }
+
+    printf("当前数值：%d %d %d %d\n", *values[0], *values[1], *values[2],
+           *values[3]);
+
+    if (pool_alloc(pool) == NULL) {
+        puts("内存池已满，下一次分配返回 NULL");
+    }
+
+    pool_free(pool, values[1]);
+    reused_value = (int *)pool_alloc(pool);
+    if (reused_value == NULL) {
+        fputs("内存池复用失败\n", stderr);
+        pool_destroy(pool);
+        return 1;
+    }
+    *reused_value = 99;
+    printf("复用后的数值：%d\n", *reused_value);
+
+    pool_destroy(pool);
+    return 0;
+}
+
+```
+
+`pool_create`创建内存池，`pool_create`的作用是类似动态管理的堆区。创建内存池时需指定内存池类型：`int`,`float`等都可以，由于 `max_align_t alignment`是最严格的对齐要求，所以无论是`pool_create`、`pool_alloc`，还是首地址都满足它们的对齐，那么创建时满足`block_size ≤ MEMORY_POOL_MAX_BLOCK_SIZE`即可。注意在创建时每个内存块的`block_size` 指定每块字节数；`block_count` 指定块数量,`block_count`最大不超过`MEMORY_POOL_MAX_BLOCK_COUNT`，当创建`block_count<MEMORY_POOL_MAX_BLOCK_COUNT`时只有`block_count`个内存块可以使用，剩下的内存块将不可以使用，创建时的最大内存池数量为`MEMORY_POOL_MAX_INSTANCES`,超过后将不再可以进行创建.
+`pool_alloc`的作用类似与`malloc`,从内存池中分配一个内存块.`pool_free`是通过`pool_block_index`查找对应的内存块位置并进行内存的回收，`pool_free`的作用类似与`free`,
+`pool_destroy`将创建的内存池进行回收方便创建新的其他类型的内存池，否则创建的内存池数量超过`MEMORY_POOL_MAX_INSTANCES`时将不可以再次创建，由于创建的内存池依赖`memory_pools`这个静态数组,本质上是属于静态存储区BSS段,"静态存储期生命周期贯穿整个程序，若不手动 pool_destroy，它们会一直占用 MEMORY_POOL_MAX_INSTANCES 个名额直到程序退出"由 OS 统一回收。如果不进行二次使用可以不进行回收但还是希望养成好习惯.
+
+编译运行这个内存池示例：
+
+```bash
+gcc -std=c11 -Wall -Wextra memory_pool.c -o memory_pool && ./memory_pool
+```
+
+运行结果：
+
+```text
+当前数值：10 20 30 40
+内存池已满，下一次分配返回 NULL
+复用后的数值：99
+```
+
+:::
+
 想一下：内存池相比直接 `malloc`/`free`，在嵌入式或实时系统里有什么好处？为什么它能做到 O(1) 分配释放、且不产生碎片？
 
 ### 练习 4：带统计的 malloc/free 包装器（挑战·可选）
@@ -347,5 +620,214 @@ void        pool_destroy(MemoryPool* pool);
 ```c
 #define TMALLOC(size) tracked_malloc((size), __FILE__, __LINE__)
 ```
+
+::: details 参考答案
+
+```c
+//debug_log.h
+#pragma once
+
+#include <stdio.h>
+
+/* 默认开启日志；编译时用 -DNDEBUG 可关闭 */
+#ifdef NDEBUG
+    #define DEBUG_LOG(fmt, ...)  ((void)(0))
+#else
+    #define DEBUG_LOG(fmt, ...) \
+        fprintf(stderr, "[%s:%d] " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#endif
+```
+
+```c
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "debug_log.h"
+
+// malloc/free 跟踪记录的最大数量。
+#define TRACKED_ALLOCATION_MAX 128U
+  
+// active为1 表示该内存块尚未被 free，属于潜在泄漏； 0 表示已被 free 或已被重复释放检测使用。
+typedef struct {
+    void *address;//实际 malloc 返回的内存块首地址（NULL 表示空）；
+    size_t size;//本次分配的字节数，由调用方传入的 size 决定；
+    const char *file;//记录该次分配发生所在源文件（由 __FILE__ 宏提供）；
+    unsigned int line;//记录该次分配发生所在行号（由 __LINE__ 宏提供）；
+    int active;//标记该记录当前是否仍处于“活跃”状态：
+} AllocationRecord;
+
+static AllocationRecord allocation_records[TRACKED_ALLOCATION_MAX];
+
+//内存报告注册标志。记录 atexit(mem_report) 是否注册成功：
+static int mem_report_registered;
+
+/* mem_report 的声明：定义在文件下方，先在此声明以供 atexit 使用。 */
+void mem_report(void);
+
+/* 注册内存报告退出钩子：在第一次使用跟踪器时调用。
+ * 作用：向 atexit 注册 mem_report，使程序退出时自动打印泄漏统计。
+ * 通过 mem_report_registered 标志保证只在第一次真正需要时注册一次，
+ * 之后就跳过，避免在同一函数里重复注册造成浪费或冲突。 */
+static void register_mem_report(void)
+{
+    if (!mem_report_registered) {
+        if (atexit(mem_report) == 0) {
+            mem_report_registered = 1;
+        } else {
+            fputs("无法注册内存报告退出钩子\n", stderr);
+        }
+    }
+}
+//在记录表中查找指定地址对应的记录。
+ //address 要查找的 malloc 起始地址；
+// active_only 为真(非0)时只查找仍处于活跃(active==1)状态的记录，
+//为假(0)时查找任意状态的记录（包含已释放的）。
+
+static AllocationRecord *find_record(void *address, int active_only)
+{
+    size_t i;
+
+    for (i = 0U; i < TRACKED_ALLOCATION_MAX; ++i) {
+        if (allocation_records[i].address == address &&
+            (!active_only || allocation_records[i].active)) {
+            return &allocation_records[i];
+        }
+    }
+    return NULL;
+}
+
+//带跟踪的 malloc：调用真正的 malloc 并登记一条分配记录。
+void *tracked_malloc(size_t size, const char *file, unsigned int line)
+{
+    AllocationRecord *record = NULL;
+    void *address;
+    size_t i;
+
+    register_mem_report();
+    address = malloc(size);
+    if (address == NULL) {
+        return NULL;
+    }
+
+    /* 统一输出本次分配的大小，方便观察挂钩/监控效果。 */
+    printf("size = %zu\n", size);
+
+    /* 在记录表中查找第一个空闲槽位。 */
+    for (i = 0U; i < TRACKED_ALLOCATION_MAX; ++i) {
+        if (!allocation_records[i].active) {
+            record = &allocation_records[i];
+            break;
+        }
+    }
+
+    /* 记录表已满：无法跟踪这次分配，撤销分配以免造成无法追踪的泄漏。 */
+    if (record == NULL) {
+        fputs("内存跟踪记录表已满，分配被撤销\n", stderr);
+        free(address);
+        return NULL;
+    }
+
+    /* 填充该槽位的信息，并把 active 置 1 表示内存块处于活跃状态。 */
+    record->address = address;
+    record->size = size;
+    record->file = file;
+    record->line = line;
+    record->active = 1;
+    return address;
+}
+
+//带跟踪的 free：调用真正的 free 并维护对应的分配记录。
+void tracked_free(void *address, const char *file, unsigned int line)
+{
+    AllocationRecord *record;
+
+    if (address == NULL) {
+        return;
+    }
+
+    record = find_record(address, 1);
+    if (record != NULL) {
+        record->active = 0;
+        free(address);
+        return;
+    }
+
+    /* 已经释放过的地址保留在表中，用于识别重复释放。 */
+    record = find_record(address, 0);
+    if (record != NULL) {
+        fprintf(stderr, "重复释放地址 %p（调用位置 %s:%u）\n",
+                address, file, line);
+    } else {
+        fprintf(stderr, "忽略未登记地址 %p 的释放（调用位置 %s:%u）\n",
+                address, file, line);
+    }
+}
+
+/* 内存泄漏报告函数：由 atexit 在程序退出时自动调用。
+ * 功能：
+ *   遍历整张记录表，统计仍处于活跃状态的记录并逐条打印，
+ *   最后给出汇总结论（无泄漏 / 泄漏块数量）。
+ */
+void mem_report(void)
+{
+    size_t i;
+    size_t leak_count = 0U;
+
+    for (i = 0U; i < TRACKED_ALLOCATION_MAX; ++i) {
+        if (allocation_records[i].active) {
+            ++leak_count;
+            DEBUG_LOG("内存泄漏 #%zu: 地址=%p, 大小=%zu 字节, 分配位置=%s:%u",
+                      leak_count, allocation_records[i].address,
+                      allocation_records[i].size, allocation_records[i].file,
+                      allocation_records[i].line);
+        }
+    }
+
+    if (leak_count == 0U) {
+        fputs("内存报告：没有未释放的内存\n", stderr);
+    } else {
+        DEBUG_LOG("内存报告：共 %zu 个未释放块", leak_count);
+    }
+}
+
+/* 宏封装：把普通 malloc/free 替换成带文件名与行号的跟踪版本。
+ * TMALLOC(size)  实际调用 tracked_malloc，并自动填入 __FILE__、__LINE__；
+ * TFREE(address) 实际调用 tracked_free，并自动填入 __FILE__、__LINE__。
+ * 这样调用者无需手动编写文件名与行号参数，易于日常使用。 */
+#define TMALLOC(size) tracked_malloc((size), __FILE__, __LINE__)
+#define TFREE(address) tracked_free((address), __FILE__, __LINE__)
+
+/* 程序入口：演示跟踪内存分配、释放与退出报告流程。 */
+int main(void)
+{
+    void *tracked_block;
+    int *problem_block;
+
+    tracked_block = TMALLOC(32U);
+    problem_block = TMALLOC(sizeof(int)*4);
+    if (tracked_block == NULL) {
+        fputs("跟踪内存分配失败\n", stderr);
+        return 1;
+    }
+     TFREE(tracked_block);
+     TFREE(problem_block);
+    return 0;
+}
+```
+
+运行结果：
+
+```bash
+gcc -std=gnu11 -Wall -Wextra tracked.c -o tracked && ./tracked
+```
+
+```text
+size = 32
+size = 16
+内存报告：没有未释放的内存
+```
+
+:::
 
 提示：用一个数组或链表记录每次分配的地址、大小、位置；`free` 时按地址匹配并标记已释放；`atexit(mem_report)` 注册退出时打印剩余未释放项。

--- a/documents/vol1-fundamentals/c_tutorials/14-dynamic-memory.md
+++ b/documents/vol1-fundamentals/c_tutorials/14-dynamic-memory.md
@@ -11,7 +11,7 @@ order: 18
 platform: host
 prerequisites:
 - 结构体与内存对齐
-reading_time_minutes: 9
+reading_time_minutes: 35
 tags:
 - host
 - cpp-modern
@@ -815,6 +815,12 @@ int main(void)
     return 0;
 }
 ```
+
+atexit 是 C/C++ 标准库 <stdlib.h> 中用来注册一个在程序正常退出时自动执行的回调函数。
+`tracked_malloc`使用`malloc`和`__FILE__, __LINE__`机制动态分配内存并将分配时的位置记录，方便日后忘回收时进行快速查找
+通过`allocation_records`记录表将状态进行记录
+`tracked_free`使用`free`和`__FILE__, __LINE__`机制释放内存和查找是否重复释放和释放错误地址，通过`find_record`进行对释放地址的判断
+`register_mem_report`在首次`tracked_malloc`是进行`atexit`注册`mem_repor`确定程序运行结束后内存的状态（判断是否全部释放和有几个未释放和当初的分配位置
 
 运行结果：
 

--- a/documents/vol1-fundamentals/c_tutorials/15-preprocessor-and-multifile.md
+++ b/documents/vol1-fundamentals/c_tutorials/15-preprocessor-and-multifile.md
@@ -11,7 +11,7 @@ order: 19
 platform: host
 prerequisites:
 - 动态内存管理
-reading_time_minutes: 6
+reading_time_minutes: 12
 tags:
 - host
 - cpp-modern

--- a/documents/vol1-fundamentals/c_tutorials/15-preprocessor-and-multifile.md
+++ b/documents/vol1-fundamentals/c_tutorials/15-preprocessor-and-multifile.md
@@ -212,6 +212,127 @@ int main(void) {
 }
 ```
 
+::: details 参考答案
+
+```c
+// math_utils.h
+// math_utils.h
+#pragma once
+/**
+ * @brief 返回两个值中的最大值
+ *
+ */
+#define MAX(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a > _b ? _a : _b;      \
+  })
+
+/**
+ * @brief 返回两个值中的最小值
+ *
+ */
+#define MIN(a, b)           \
+  ({                        \
+    __typeof__(a) _a = (a); \
+    __typeof__(b) _b = (b); \
+    _a < _b ? _a : _b;      \
+  })
+
+
+void clamp_int(int *value, int min_val,int max_val);
+
+/**
+ * @brief Print and return the number of decimal digits in an integer.
+ *
+ * The sign is not counted. Zero has one digit.
+ */
+int count_digits(int value);
+
+// int main(void) {
+//     // 练习： 调用两个函数，验证结果
+//     return 0;
+// }
+
+```
+
+```c
+// math_utils.c
+#include "math_utils.h"
+#include <stdio.h>
+
+void clamp_int(int *value, int min_val,int max_val)
+{
+   *value = MAX(min_val, MIN(*value, max_val));
+}
+
+int count_digits(int value)
+{
+    int digits = 0;
+
+    do {
+        ++digits;
+        value /= 10;
+    } while (value != 0);
+
+    printf("%d\n", digits);
+    return digits;
+}
+
+```
+
+```c
+// main.c
+#include <stdio.h>
+
+#include "math_utils.h"
+
+int main(void)
+{
+    int v;
+    int digits;
+  
+    v = 5;
+    clamp_int(&v, 0, 10);
+    printf("clamp_int(5, 0, 10) = %d\n", v);
+
+    v = 100;
+    clamp_int(&v, 0, 10);
+    printf("clamp_int(100, 0, 10) = %d\n", v);
+
+    digits = count_digits(42);
+    printf("count_digits(42) = %d\n", digits);
+
+    digits = count_digits(-12345);
+    printf("count_digits(-12345) = %d\n", digits);
+
+    printf("All tests passed.\n");
+    return 0;
+}
+
+```
+
+```bash
+gcc -std=gnu11 -Wall -Wextra main.c math_utils.c -o main
+```
+
+运行结果：
+
+```text
+clamp_int(5, 0, 10) = 5
+clamp_int(100, 0, 10) = 10
+2
+count_digits(42) = 2
+5
+count_digits(-12345) = 5
+All tests passed.
+```
+
+:::
+
+
+
 提示：编译步骤是 `gcc -c math_utils.c`、`gcc -c main.c`、`gcc -o demo main.o math_utils.o`。打包静态库用 `ar rcs libmath_utils.a math_utils.o`。
 
 ### 练习 2：零开销的 DEBUG_LOG 宏
@@ -229,5 +350,77 @@ int main(void) {
 // 提示：使用 __FILE__、__LINE__、__VA_ARGS__
 #endif
 ```
+
+::: details 参考答案
+
+```c
+//debug_log.h
+#pragma once
+
+#include <stdio.h>
+
+/* 默认开启日志；编译时用 -DNDEBUG 可关闭 */
+#ifdef NDEBUG
+    #define DEBUG_LOG(fmt, ...)  ((void)(0))
+#else
+    #define DEBUG_LOG(fmt, ...) \
+        fprintf(stderr, "[%s:%d] " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__)
+#endif
+```
+
+```#include "debug_log.h"
+#include <stdio.h>
+
+int main(void)
+{
+    int count = 0;
+    DEBUG_LOG("开始运行，初始值 count = %d", count);
+
+    for (int i = 0; i < 3; ++i) {
+        DEBUG_LOG("第 %d 次循环", i);
+        count += i;
+    }
+
+    DEBUG_LOG("结束，最终 count = %d", count);
+    DEBUG_LOG("这是不带额外参数的中文消息");
+
+    printf("完成。\n");
+    return 0;
+}
+```
+
+`Debug 模式`
+
+```bash
+ gcc -std=gnu11 -Wall -Wextra main.c -o main &&./main
+```
+
+`Release 模式`
+
+```bash
+gcc -std=gnu11 -Wall -Wextra  -DNDEBUG  -Wno-unused-variable  main.c -o main &&./main
+```
+
+运行结果：
+
+Debug 模式：
+
+```text
+[main.c:7] 开始运行，初始值 count = 0
+[main.c:10] 第 0 次循环
+[main.c:10] 第 1 次循环
+[main.c:10] 第 2 次循环
+[main.c:14] 结束，最终 count = 3
+[main.c:15] 这是不带额外参数的中文消息
+完成。
+```
+
+Release 模式：`DEBUG_LOG` 被展开为 `((void)(0))`，什么都不输出，只留下 `printf` 的那一行：
+
+```text
+完成。
+```
+
+:::
 
 提示：可变参数宏的写法是 `#define DEBUG_LOG(fmt, ...) fprintf(stderr, fmt, __VA_ARGS__)`。GCC 提供了 `##__VA_ARGS__` 扩展处理没有额外参数时的逗号问题。

--- a/documents/vol1-fundamentals/c_tutorials/16-file-io-and-stdlib.md
+++ b/documents/vol1-fundamentals/c_tutorials/16-file-io-and-stdlib.md
@@ -106,9 +106,12 @@ size_t count = fread(buffer, sizeof(Record), max_count, fp);
 
 ```c
 long get_file_size(FILE* fp) {
+    //获取当前初始位置
     long original = ftell(fp);
+    //将文件位置移至文件末尾
     fseek(fp, 0, SEEK_END);
     long size = ftell(fp);
+    //将文件位置从开头移至文件初始位置
     fseek(fp, original, SEEK_SET);
     return size;
 }
@@ -116,7 +119,7 @@ long get_file_size(FILE* fp) {
 
 ### 别把 feof 当循环条件
 
-`feof` 只有在读取操作已经失败**之后**才会返回真。正确的做法是直接检查读取函数的返回值：
+`feof` 只有在读取操作已经失败**之后**才会返回真。当`feof` 读到`EOF`时，会返回零后再次执行`feof`时才会返回1.将正确的做法是直接检查读取函数的返回值：
 
 ```c
 int ch;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -299,6 +299,12 @@ async function buildVolume(task: BuildTask): Promise<string> {
   if (lang === 'en') {
     mkdirSync(join(volSrcDir, 'en'), { recursive: true })
     cpSync(volDocDir, join(volSrcDir, 'en', vol.srcDir), { recursive: true })
+    if (vol.srcDir === 'compilation') {
+      const sharedAssets = join(DOCUMENTS, 'compilation', 'compilation-linking-2-reuse-concept')
+      if (existsSync(sharedAssets)) {
+        cpSync(sharedAssets, join(volSrcDir, 'compilation', 'compilation-linking-2-reuse-concept'), { recursive: true })
+      }
+    }
   } else {
     mkdirSync(volSrcDir, { recursive: true })
     cpSync(volDocDir, join(volSrcDir, vol.srcDir), { recursive: true })


### PR DESCRIPTION
## 变更类型

- [x] 现有文章改进
- [ ] Bug 修复
- [ ] 新增文章
- [ ] 翻译或双语同步
- [ ] 其他

## 变更说明

完善 C 语言教程中《结构体和内存对齐》与《联合体、枚举、位域与 typedef》的练习参考答案，帮助读者通过完整示例理解内存对齐、协议解析以及带标签联合体（tagged union）的使用方式。

本次主要修改包括：

- 完善《结构体和内存对齐》的练习参考答案
  - 补充 struct packing / 内存对齐的完整示例
  - 说明对齐、填充（padding）与 `__attribute__((packed))` 等定义
  - 补充通信协议帧（protocol frame）的定义与解析示例
- 完善《联合体、枚举、位域与 typedef》的练习参考答案
  - 补充联合体（union）共享内存的用法
  - 补充位域（bitfield）的实现示例
  - 补充带标签联合体（tagged union）区分数据类型的实现
- 修正 `02-reuse-concept.md` 中静态/动态库图片的相对路径，使其在文档目录下正确加载

## 影响范围

- 仅涉及：
  - `documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md`
  - `documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md`
  - `documents/en/compilation/02-reuse-concept.md`（仅修正图片路径，无翻译改动）
- 不涉及网站导航或 Frontmatter 结构
- 不涉及项目运行时代码

## 验证情况

- 所有新增示例均通过 GCC C11 编译
- 使用 `-Wall -Wextra -Wpedantic -Werror` 编译通过
- 已实际运行并核对示例输出
- `pnpm check:links` 通过
- Frontmatter 校验通过
- `git diff --check` 通过