### PR TITLE
docs(c): 完善 C 字符串、结构体与联合体练习参考答案

### DIFF
--- a/documents/vol1-fundamentals/c_tutorials/11-c-strings-and-buffer-safety.md
+++ b/documents/vol1-fundamentals/c_tutorials/11-c-strings-and-buffer-safety.md
@@ -457,6 +457,10 @@ int main(void)
 
 ```
 
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic safe_strings.c -o safe_strings && ./safe_strings
+```
+
 运行结果：
 
 ```text
@@ -542,6 +546,10 @@ int main(void)
     return 0;
 }
 
+```
+
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic safe_str_format.c -o safe_str_format && ./safe_str_format
 ```
 
 运行结果：
@@ -668,11 +676,11 @@ int main(void)
     return 0;
 }
 
-
-
 ```
 
-
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic str_split.c -o str_split && ./str_split
+```
 
 ```text
 原始字符串：温度,湿度,气压
@@ -682,6 +690,8 @@ int main(void)
 第 2 个字段：湿度（长度为 6 字节）
 第 3 个字段：气压（长度为 6 字节）
 ```
+
+
 
 `str_split` 返回的是原字符串中的指针和长度，因此这些指针只在 `input` 仍然有效时可用。
 打印时使用 `%.*s` 配合长度，不要求每个字段单独拥有一个 `\0` 终止符；如果需要独立保存

--- a/documents/vol1-fundamentals/c_tutorials/11-c-strings-and-buffer-safety.md
+++ b/documents/vol1-fundamentals/c_tutorials/11-c-strings-and-buffer-safety.md
@@ -416,16 +416,16 @@ size_t safe_str_cat(char *dst, const char *src, size_t dst_size)
 
 int main(void)
 {
-    char copied_text[32];// 目标缓冲区
-    char short_buffer[8];// 较小的缓冲区
-    char combined_text[32] = "STM32";// 已有内容的目标缓冲区
-    char short_combined[8] = "STM32";// 用于演示拼接截断
-    char self_combined[16] = "ab";// 用于演示源、目标重叠
-    size_t copied_length;// 源字符串的完整长度
-    size_t short_length;// 源字符串的完整长度
-    size_t combined_length;// 拼接后的总字节数
-    size_t short_combined_length;// 完整拼接所需的长度
-    size_t self_combined_length;// 重叠拼接后的完整长度
+    char copied_text[32]; // 目标缓冲区
+    char short_buffer[8]; // 较小的缓冲区
+    char combined_text[32] = "STM32"; // 已有内容的目标缓冲区
+    char short_combined[8] = "STM32"; // 用于演示拼接截断
+    char self_combined[16] = "ab"; // 用于演示源、目标重叠
+    size_t copied_length; // 源字符串的完整长度
+    size_t short_length; // 源字符串的完整长度
+    size_t combined_length; // 拼接后的总字节数
+    size_t short_combined_length; // 完整拼接所需的长度
+    size_t self_combined_length; // 重叠拼接后的完整长度
 
     copied_length = safe_str_copy(copied_text, "Hello, Embedded!",
                                   sizeof(copied_text));
@@ -456,6 +456,8 @@ int main(void)
 }
 
 ```
+
+编译运行：
 
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic safe_strings.c -o safe_strings && ./safe_strings
@@ -527,10 +529,10 @@ size_t safe_str_format(char *dst, size_t dst_size, const char *format, ...)
 
 int main(void)
 {
-    char message[64];//缓冲区
-    char short_message[12];//较小的缓冲区
-    size_t message_length;//格式化后消息的长度
-    size_t short_length;//完整格式化结果的长度
+    char message[64]; // 缓冲区
+    char short_message[12]; // 较小的缓冲区
+    size_t message_length; // 格式化后消息的长度
+    size_t short_length; // 完整格式化结果的长度
 
     message_length = safe_str_format(message, sizeof(message),
                                      "设备：%s，温度：%d 摄氏度",
@@ -547,6 +549,8 @@ int main(void)
 }
 
 ```
+
+编译运行：
 
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic safe_str_format.c -o safe_str_format && ./safe_str_format
@@ -650,11 +654,11 @@ size_t str_split(
 
 int main(void)
 {
-    const char* input = "温度,湿度,气压";//原始字符串
-    const char delimiter = ',';//分割符号
-    const char* token_starts[16];//存储子串起始指针的数组
-    size_t token_lengths[16];//存储子串长度的数组
-    size_t token_count;//实际分割出的子串数量
+    const char* input = "温度,湿度,气压"; // 原始字符串
+    const char delimiter = ','; // 分割符号
+    const char* token_starts[16]; // 存储子串起始指针的数组
+    size_t token_lengths[16]; // 存储子串长度的数组
+    size_t token_count; // 实际分割出的子串数量
     size_t i;
 
     token_count = str_split(input, delimiter,
@@ -677,6 +681,8 @@ int main(void)
 }
 
 ```
+
+编译运行：
 
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic str_split.c -o str_split && ./str_split

--- a/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
+++ b/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
@@ -532,6 +532,8 @@ int main(void)
 }
 ```
 
+编译运行：
+
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic alignment_verify.c -o alignment_verify && ./alignment_verify
 ```
@@ -624,6 +626,8 @@ int main(void)
 }
 ```
 
+编译运行：
+
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic packed_compare.c -o packed_compare && ./packed_compare
 ```
@@ -710,9 +714,9 @@ uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
 /* CRC 查表和接口命名改编自 RoboMaster 官方例程；为便于对照保留原命名。 */
 
 
-//查表法CRC
+// 查表法 CRC
 
-//CRC8 使用的初始值。
+// CRC8 使用的初始值。
 static const uint8_t k_crc8_init = 0xffu;
 
 // CRC8 预计算状态转移表。
@@ -742,7 +746,7 @@ static const uint8_t k_crc8_tab[256] = {
     0xd7, 0x89, 0x6b, 0x35,
 };
 
-//系统整帧 CRC16 使用的初始值。
+// 系统整帧 CRC16 使用的初始值。
 static const uint16_t k_crc16_init = 0xffffu;
 
 // CRC16 预计算状态转移表。
@@ -778,7 +782,7 @@ static const uint16_t k_crc16_tab[256] = {
     0x3de3, 0x2c6a, 0x1ef1, 0x0f78,
 };
 
-//计算一段连续字节的 CRC8。
+// 计算一段连续字节的 CRC8。
 uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
                            uint8_t ucCRC8)
 {
@@ -793,7 +797,7 @@ uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
   return ucCRC8;
 }
 
-//校验缓冲区末尾已保存的 CRC8。
+// 校验缓冲区末尾已保存的 CRC8。
 bool Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
 {
   uint8_t expected = 0u;
@@ -804,13 +808,13 @@ bool Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
     return false;
   }
 
-  //计算窗口排除末尾已经保存的 CRC8 字节。
+  // 计算窗口排除末尾已经保存的 CRC8 字节。
   expected = Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u),
                                 k_crc8_init);
   return expected == pchMessage[dwLength - 1u];
 }
 
-//把重新计算得到的 CRC8 写入缓冲区末尾。
+// 把重新计算得到的 CRC8 写入缓冲区末尾。
 void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
 {
   // 不向空指针或长度不足的缓冲区写入。
@@ -819,12 +823,12 @@ void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
     return;
   }
 
-  //校验字节本身不参与本轮 CRC8 计算。
+  // 校验字节本身不参与本轮 CRC8 计算。
   pchMessage[dwLength - 1u] =
       Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u), k_crc8_init);
 }
 
-//计算一段连续字节的 CRC16。
+// 计算一段连续字节的 CRC16。
 uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
                              uint16_t wCRC)
 {
@@ -845,36 +849,36 @@ uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
   return wCRC;
 }
 
-//校验完整帧末尾 2 字节保存的 CRC16。
+// 校验完整帧末尾 2 字节保存的 CRC16。
 
 bool Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
 {
   uint16_t expected = 0u;
 
-  //完整帧至少要包含受保护数据和 2 字节 CRC16。
+  // 完整帧至少要包含受保护数据和 2 字节 CRC16。
   if ((pchMessage == NULL) || (dwLength <= 2u))
   {
     return false;
   }
 
-  //只重算受保护的载荷/帧头区域，末尾 CRC16 不参与计算。
+  // 只重算受保护的载荷/帧头区域，末尾 CRC16 不参与计算。
   expected = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
   return (((expected & 0x00ffu) == pchMessage[dwLength - 2u]) &&
           (((expected >> 8u) & 0x00ffu) == pchMessage[dwLength - 1u]));
 }
 
-//把 CRC16 追加到完整帧缓冲区末尾 2 字节。
+// 把 CRC16 追加到完整帧缓冲区末尾 2 字节。
 void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
 {
   uint16_t wCRC = 0u;
 
-  //不向空指针或长度不足的帧缓冲区写入。
+  // 不向空指针或长度不足的帧缓冲区写入。
   if ((pchMessage == NULL) || (dwLength <= 2u))
   {
     return;
   }
 
-  //小端协议：低字节在前，高字节在后。
+  // 小端协议：低字节在前，高字节在后。
   wCRC = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
   pchMessage[dwLength - 2u] = (uint8_t)(wCRC & 0x00ffu);
   pchMessage[dwLength - 1u] = (uint8_t)((wCRC >> 8u) & 0x00ffu);

--- a/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
+++ b/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
@@ -8,7 +8,7 @@ order: 16
 platform: host
 prerequisites:
 - restrict、不完整类型与结构体指针
-reading_time_minutes: 20
+reading_time_minutes: 50
 tags:
 - host
 - cpp-modern
@@ -99,7 +99,7 @@ SensorReading r3 = {
 
 指定初始化器的好处非常明显：代码自文档化，不依赖字段顺序，未指定的字段自动清零。说实话，在现代 C 代码中，只要你用的编译器支持 C99（基本上都支持），就应该优先使用指定初始化器。
 
-结构体的赋值和初始化是两回事。初始化发生在声明时，赋值发生在声明之后。C 语言允许同类型的结构体之间直接赋值，这是逐字节复制的：
+结构体的赋值和初始化是两回事。初始化发生在声明时，赋值发生在声明之后。C 语言允许同类型的结构体之间直接赋值，赋值后各个成员的值与源对象对应成员相同：
 
 ```c
 SensorReading r4;
@@ -236,7 +236,7 @@ printf("alignof(double)   = %zu\n", alignof(double));    // 通常 8
 printf("alignof(WeirdLayout) = %zu\n", alignof(WeirdLayout)); // 4
 ```
 
-结构体的对齐要求等于其成员中最大的对齐要求。`WeirdLayout` 里有 `uint32_t`，所以整体对齐要求是 4。
+在没有额外对齐说明时，大多数 ABI 会让结构体的对齐要求不低于其成员中最严格的一项。`WeirdLayout` 里有 `uint32_t`，因此当前实验环境中整体对齐要求是 4；需要跨平台确认时，仍应以 `alignof(WeirdLayout)` 的结果为准。
 
 ### alignas：强制对齐
 
@@ -332,7 +332,7 @@ free(pkt);
 
 柔性数组成员在通信协议、变长消息处理、数据包解析中用得非常多。在 C 的早期年代，人们用一种叫做"struct hack"的技巧来实现类似功能——在结构体末尾放一个长度为 1（或 0）的数组，然后多分配一些空间。但那是未定义行为，C99 的 FAM 才是标准做法。
 
-有一点需要注意：含柔性数组成员的结构体不能按值传递或复制——因为 `sizeof` 不知道尾部数据有多大。你只能通过指针来操作它们。
+有一点需要注意：含柔性数组成员的结构体**可以**按值传递、赋值或返回，但这些操作只复制固定成员，不会复制尾随数据。协议帧和变长消息通常仍应通过指针传递，或者显式分配目标缓冲区并复制完整字节范围；否则很容易误以为 payload 也一起被复制了。
 
 ## 结构体数组
 
@@ -392,7 +392,7 @@ typedef struct __attribute__((packed)) {
 
 加了这个属性后，`sizeof(PackedFrame)` 就是纯粹的 1 + 2 + 1 + 4 = 8 字节，没有任何填充。但要注意代价——访问未对齐的字段在某些架构上会导致性能下降甚至硬件异常。所以 `packed` 应该只在你确实需要紧凑布局的时候使用，而不是到处乱加。ARM Cortex-M 系列在大多数情况下能处理未对齐访问（有性能损失），但有些老架构（比如 ARM7TDMI）会直接 fault。
 
-一个更安全的做法是：**通信层用 packed 结构体解析原始字节，然后立即转换成对齐的内部结构体来使用**。解析和业务逻辑分离，各取所需。
+`packed` 只约束布局，既不处理大端、小端，也不会让任意 `uint8_t` 接收缓冲区都能安全地强转为结构体指针。更稳妥的做法是：通信层按字节读取，或先 `memcpy` 到对齐良好的临时对象后再逐字段解码；随后转换成自然对齐的内部结构体供业务代码使用。解析和业务逻辑分离，各取所需。
 
 ## C++ 衔接
 
@@ -493,6 +493,57 @@ typedef struct {
 
 ::: details 参考答案
 
+先把三个结构体补成完整程序，用 `offsetof` 和 `sizeof` 验证手算结果：
+
+```c
+#include <stddef.h>
+#include <stdio.h>
+
+typedef struct {
+    char a;
+    int b;
+    char c;
+} StructA;
+
+typedef struct {
+    int b;
+    char a;
+    char c;
+} StructB;
+
+typedef struct {
+    char a;
+    char c;
+    int b;
+} StructC;
+
+int main(void)
+{
+    printf("StructA: a=%zu, b=%zu, c=%zu, sizeof=%zu\n",
+           offsetof(StructA, a), offsetof(StructA, b),
+           offsetof(StructA, c), sizeof(StructA));
+    printf("StructB: a=%zu, b=%zu, c=%zu, sizeof=%zu\n",
+           offsetof(StructB, a), offsetof(StructB, b),
+           offsetof(StructB, c), sizeof(StructB));
+    printf("StructC: a=%zu, b=%zu, c=%zu, sizeof=%zu\n",
+           offsetof(StructC, a), offsetof(StructC, b),
+           offsetof(StructC, c), sizeof(StructC));
+    return 0;
+}
+```
+
+```bash
+gcc -std=c17 -Wall -Wextra alignment_verify.c -o alignment_verify && ./alignment_verify
+```
+
+在 `int` 为 4 字节、按 4 字节对齐的测试环境中，输出如下：
+
+```text
+StructA: a=0, b=4, c=8, sizeof=12
+StructB: a=4, b=0, c=5, sizeof=8
+StructC: a=0, b=4, c=1, sizeof=8
+```
+
 手算结果（`int` 4 字节对齐）：
 
 | 结构体 | a 偏移 | b 偏移 | c 偏移 | sizeof |
@@ -534,6 +585,71 @@ typedef struct {
 
 想一想：`FramePacked` 最省空间，但为什么在有些 CPU 上访问 `value` 字段反而更慢、甚至直接崩？什么场景该用 packed，什么场景该用显式对齐？
 
+::: details 参考答案
+
+下面的程序一次把三种布局打印出来。`__attribute__((packed))` 是 GCC/Clang 扩展，所以这里使用 GCC 编译：
+
+```c
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+typedef struct {
+    uint8_t type;
+    uint32_t value;
+} FrameNormal;
+
+typedef struct __attribute__((packed)) {
+    uint8_t type;
+    uint32_t value;
+} FramePacked;
+
+typedef struct {
+    uint8_t type;
+    _Alignas(4) uint32_t value;
+} FrameAligned;
+
+int main(void)
+{
+    printf("FrameNormal: type=%zu, value=%zu, sizeof=%zu\n",
+           offsetof(FrameNormal, type), offsetof(FrameNormal, value),
+           sizeof(FrameNormal));
+    printf("FramePacked: type=%zu, value=%zu, sizeof=%zu\n",
+           offsetof(FramePacked, type), offsetof(FramePacked, value),
+           sizeof(FramePacked));
+    printf("FrameAligned: type=%zu, value=%zu, sizeof=%zu\n",
+           offsetof(FrameAligned, type), offsetof(FrameAligned, value),
+           sizeof(FrameAligned));
+    return 0;
+}
+```
+
+```bash
+gcc -std=c17 -Wall -Wextra packed_compare.c -o packed_compare && ./packed_compare
+```
+
+运行结果：
+
+```text
+FrameNormal: type=0, value=4, sizeof=8
+FramePacked: type=0, value=1, sizeof=5
+FrameAligned: type=0, value=4, sizeof=8
+```
+
+| 结构体 | `type` 偏移 | `value` 偏移 | `sizeof` |
+|---|---:|---:|---:|
+| `FrameNormal` | 0 | 4 | 8 |
+| `FramePacked` | 0 | 1 | 5 |
+| `FrameAligned` | 0 | 4 | 8 |
+
+`FramePacked` 的问题就在 `value`：它从偏移 1 开始，不能保证落在 4 字节边界上。对 x86 这类通常支持未对齐访问的 CPU，处理器往往还能把值读出来，但可能需要额外的访存操作；如果数据刚好跨过缓存行，代价会更明显。换到对齐要求严格的 CPU，编译器要么把一次读取拆成多次字节读取来绕开问题，要么生成的未对齐读取会触发硬件异常。尤其不要把 `&frame.value` 当作普通的 `uint32_t*` 传给别的接口，这个指针的对齐条件已经不可靠了。
+
+所以 `packed` 不是一个"省空间就加上"的开关。它适合必须逐字节匹配外部格式的地方，例如通信协议帧、文件头或 Flash 中的固定记录；而且它只解决布局，不会自动处理大端、小端。工程上更稳妥的做法是：收发层按字节读取或用 `packed` 描述外部格式，完成长度和字节序检查后，立刻复制、解码到正常对齐的内部结构体，再交给业务代码使用。热路径数据、结构体数组、原子变量，以及 DMA 缓冲区等对访问效率或硬件约束敏感的对象，都不该为了省几个字节贸然打包。
+
+`_Alignas` 则是反过来的工具：它是在 C11 中显式保证对象或成员满足较高的对齐要求。在这个例子里，`uint32_t` 本来就自然按 4 字节对齐，所以 `FrameAligned` 和 `FrameNormal` 的布局相同；它的价值在于把约束写在代码里，例如 DMA 缓冲区需要 32 字节对齐，或某个成员必须从指定边界开始。记住这一条就够了：外部字节格式优先考虑 `packed`，内存中的日常数据优先保持自然对齐；两者之间用一次明确的解析和转换隔开，后面的代码就不用一直背着对齐风险跑。
+
+:::
+
 ### 练习 3：通信协议帧设计（挑战·可选）
 
 **难度：挑战** · 可选，需要了解 CRC 与字节序，新手可跳过
@@ -546,9 +662,515 @@ typedef struct {
 
 提示：本篇讲过柔性数组成员、`_Alignas`、`__attribute__((packed))`、`offsetof`，这些都是你的工具。CRC 算法和字节序转换属于通信专题，这里只要求你意识到这两个问题、留好占位，不要求完整实现。
 
+::: details 参考答案
+
+
+
+crc_ref.h
+
+```c
+#ifndef CRC_REF_H
+#define CRC_REF_H
+
+#include <stdint.h>
+
+#define TRUE 1u
+#define FALSE 0u
+
+
+void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
+
+uint32_t Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
+
+
+uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
+                           uint8_t ucCRC8);
+
+
+void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
+
+
+uint32_t Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
+
+
+uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
+                             uint16_t wCRC);
+
+#endif
+
+
+```
+
+crc_ref.c
+
+```c
+
+#include "crc_ref.h"
+
+#include <stddef.h>
+
+
+//查表法CRC
+
+//CRC8 使用的初始值。
+static const uint8_t k_crc8_init = 0xffu;
+
+// CRC8 预计算状态转移表。
+// 每轮使用 current_crc ^ next_byte 作为索引，表项就是折叠该字节后的下一 CRC 状态。
+static const uint8_t k_crc8_tab[256] = {
+    0x00, 0x5e, 0xbc, 0xe2, 0x61, 0x3f, 0xdd, 0x83, 0xc2, 0x9c, 0x7e, 0x20,
+    0xa3, 0xfd, 0x1f, 0x41, 0x9d, 0xc3, 0x21, 0x7f, 0xfc, 0xa2, 0x40, 0x1e,
+    0x5f, 0x01, 0xe3, 0xbd, 0x3e, 0x60, 0x82, 0xdc, 0x23, 0x7d, 0x9f, 0xc1,
+    0x42, 0x1c, 0xfe, 0xa0, 0xe1, 0xbf, 0x5d, 0x03, 0x80, 0xde, 0x3c, 0x62,
+    0xbe, 0xe0, 0x02, 0x5c, 0xdf, 0x81, 0x63, 0x3d, 0x7c, 0x22, 0xc0, 0x9e,
+    0x1d, 0x43, 0xa1, 0xff, 0x46, 0x18, 0xfa, 0xa4, 0x27, 0x79, 0x9b, 0xc5,
+    0x84, 0xda, 0x38, 0x66, 0xe5, 0xbb, 0x59, 0x07, 0xdb, 0x85, 0x67, 0x39,
+    0xba, 0xe4, 0x06, 0x58, 0x19, 0x47, 0xa5, 0xfb, 0x78, 0x26, 0xc4, 0x9a,
+    0x65, 0x3b, 0xd9, 0x87, 0x04, 0x5a, 0xb8, 0xe6, 0xa7, 0xf9, 0x1b, 0x45,
+    0xc6, 0x98, 0x7a, 0x24, 0xf8, 0xa6, 0x44, 0x1a, 0x99, 0xc7, 0x25, 0x7b,
+    0x3a, 0x64, 0x86, 0xd8, 0x5b, 0x05, 0xe7, 0xb9, 0x8c, 0xd2, 0x30, 0x6e,
+    0xed, 0xb3, 0x51, 0x0f, 0x4e, 0x10, 0xf2, 0xac, 0x2f, 0x71, 0x93, 0xcd,
+    0x11, 0x4f, 0xad, 0xf3, 0x70, 0x2e, 0xcc, 0x92, 0xd3, 0x8d, 0x6f, 0x31,
+    0xb2, 0xec, 0x0e, 0x50, 0xaf, 0xf1, 0x13, 0x4d, 0xce, 0x90, 0x72, 0x2c,
+    0x6d, 0x33, 0xd1, 0x8f, 0x0c, 0x52, 0xb0, 0xee, 0x32, 0x6c, 0x8e, 0xd0,
+    0x53, 0x0d, 0xef, 0xb1, 0xf0, 0xae, 0x4c, 0x12, 0x91, 0xcf, 0x2d, 0x73,
+    0xca, 0x94, 0x76, 0x28, 0xab, 0xf5, 0x17, 0x49, 0x08, 0x56, 0xb4, 0xea,
+    0x69, 0x37, 0xd5, 0x8b, 0x57, 0x09, 0xeb, 0xb5, 0x36, 0x68, 0x8a, 0xd4,
+    0x95, 0xcb, 0x29, 0x77, 0xf4, 0xaa, 0x48, 0x16, 0xe9, 0xb7, 0x55, 0x0b,
+    0x88, 0xd6, 0x34, 0x6a, 0x2b, 0x75, 0x97, 0xc9, 0x4a, 0x14, 0xf6, 0xa8,
+    0x74, 0x2a, 0xc8, 0x96, 0x15, 0x4b, 0xa9, 0xf7, 0xb6, 0xe8, 0x0a, 0x54,
+    0xd7, 0x89, 0x6b, 0x35,
+};
+
+//系统整帧 CRC16 使用的初始值。
+static const uint16_t k_crc16_init = 0xffffu;
+
+// CRC16 预计算状态转移表。
+static const uint16_t k_crc16_tab[256] = {
+    0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf, 0x8c48,
+    0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5, 0xe97e, 0xf8f7, 0x1081, 0x0108,
+    0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e, 0x9cc9, 0x8d40, 0xbfdb,
+    0xae52, 0xdaed, 0xcb64, 0xf9ff, 0xe876, 0x2102, 0x308b, 0x0210, 0x1399,
+    0x6726, 0x76af, 0x4434, 0x55bd, 0xad4a, 0xbcc3, 0x8e58, 0x9fd1, 0xeb6e,
+    0xfae7, 0xc87c, 0xd9f5, 0x3183, 0x200a, 0x1291, 0x0318, 0x77a7, 0x662e,
+    0x54b5, 0x453c, 0xbdcb, 0xac42, 0x9ed9, 0x8f50, 0xfbef, 0xea66, 0xd8fd,
+    0xc974, 0x4204, 0x538d, 0x6116, 0x709f, 0x0420, 0x15a9, 0x2732, 0x36bb,
+    0xce4c, 0xdfc5, 0xed5e, 0xfcd7, 0x8868, 0x99e1, 0xab7a, 0xbaf3, 0x5285,
+    0x430c, 0x7197, 0x601e, 0x14a1, 0x0528, 0x37b3, 0x263a, 0xdecd, 0xcf44,
+    0xfddf, 0xec56, 0x98e9, 0x8960, 0xbbfb, 0xaa72, 0x6306, 0x728f, 0x4014,
+    0x519d, 0x2522, 0x34ab, 0x0630, 0x17b9, 0xef4e, 0xfec7, 0xcc5c, 0xddd5,
+    0xa96a, 0xb8e3, 0x8a78, 0x9bf1, 0x7387, 0x620e, 0x5095, 0x411c, 0x35a3,
+    0x242a, 0x16b1, 0x0738, 0xffcf, 0xee46, 0xdcdd, 0xcd54, 0xb9eb, 0xa862,
+    0x9af9, 0x8b70, 0x8408, 0x9581, 0xa71a, 0xb693, 0xc22c, 0xd3a5, 0xe13e,
+    0xf0b7, 0x0840, 0x19c9, 0x2b52, 0x3adb, 0x4e64, 0x5fed, 0x6d76, 0x7cff,
+    0x9489, 0x8500, 0xb79b, 0xa612, 0xd2ad, 0xc324, 0xf1bf, 0xe036, 0x18c1,
+    0x0948, 0x3bd3, 0x2a5a, 0x5ee5, 0x4f6c, 0x7df7, 0x6c7e, 0xa50a, 0xb483,
+    0x8618, 0x9791, 0xe32e, 0xf2a7, 0xc03c, 0xd1b5, 0x2942, 0x38cb, 0x0a50,
+    0x1bd9, 0x6f66, 0x7eef, 0x4c74, 0x5dfd, 0xb58b, 0xa402, 0x9699, 0x8710,
+    0xf3af, 0xe226, 0xd0bd, 0xc134, 0x39c3, 0x284a, 0x1ad1, 0x0b58, 0x7fe7,
+    0x6e6e, 0x5cf5, 0x4d7c, 0xc60c, 0xd785, 0xe51e, 0xf497, 0x8028, 0x91a1,
+    0xa33a, 0xb2b3, 0x4a44, 0x5bcd, 0x6956, 0x78df, 0x0c60, 0x1de9, 0x2f72,
+    0x3efb, 0xd68d, 0xc704, 0xf59f, 0xe416, 0x90a9, 0x8120, 0xb3bb, 0xa232,
+    0x5ac5, 0x4b4c, 0x79d7, 0x685e, 0x1ce1, 0x0d68, 0x3ff3, 0x2e7a, 0xe70e,
+    0xf687, 0xc41c, 0xd595, 0xa12a, 0xb0a3, 0x8238, 0x93b1, 0x6b46, 0x7acf,
+    0x4854, 0x59dd, 0x2d62, 0x3ceb, 0x0e70, 0x1ff9, 0xf78f, 0xe606, 0xd49d,
+    0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330, 0x7bc7, 0x6a4e, 0x58d5, 0x495c,
+    0x3de3, 0x2c6a, 0x1ef1, 0x0f78,
+};
+
+//计算一段连续字节的 CRC8。
+uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
+                           uint8_t ucCRC8)
+{
+  uint8_t ucIndex = 0u;
+
+  //? 每轮消耗 1 字节，并把该字节折叠进当前 CRC 状态。
+  while (dwLength-- != 0u)
+  {
+    ucIndex = ucCRC8 ^ (*pchMessage++);
+    ucCRC8 = k_crc8_tab[ucIndex];
+  }
+  return ucCRC8;
+}
+
+//校验缓冲区末尾已保存的 CRC8。
+uint32_t Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
+{
+  uint8_t expected = 0u;
+
+  // 系统帧头至少要包含有效字段和 1 字节 CRC8。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return FALSE;
+  }
+
+  //计算窗口排除末尾已经保存的 CRC8 字节。
+  expected = Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u),
+                                k_crc8_init);
+  return (expected == pchMessage[dwLength - 1u]) ? TRUE : FALSE;
+}
+
+//把重新计算得到的 CRC8 写入缓冲区末尾。
+void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
+{
+  // 不向空指针或长度不足的缓冲区写入。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return;
+  }
+
+  //校验字节本身不参与本轮 CRC8 计算。
+  pchMessage[dwLength - 1u] =
+      Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u), k_crc8_init);
+}
+
+//计算一段连续字节的 CRC16。
+uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
+                             uint16_t wCRC)
+{
+  uint8_t chData = 0u;
+
+  if (pchMessage == NULL)
+  {
+    return 0xffffu;
+  }
+
+  // 将每个输入字节折叠到 CRC 低位，再通过查表推进到下一状态。
+  while (dwLength-- != 0u)
+  {
+    chData = *pchMessage++;
+    wCRC = (uint16_t)((wCRC >> 8u) ^
+                      k_crc16_tab[(uint8_t)(wCRC ^ chData)]);
+  }
+  return wCRC;
+}
+
+//校验完整帧末尾 2 字节保存的 CRC16。
+
+uint32_t Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
+{
+  uint16_t expected = 0u;
+
+  //完整帧至少要包含受保护数据和 2 字节 CRC16。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return FALSE;
+  }
+
+  //只重算受保护的载荷/帧头区域，末尾 CRC16 不参与计算。
+  expected = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
+  return (((expected & 0x00ffu) == pchMessage[dwLength - 2u]) &&
+          (((expected >> 8u) & 0x00ffu) == pchMessage[dwLength - 1u]))
+             ? TRUE
+             : FALSE;
+}
+
+//把 CRC16 追加到完整帧缓冲区末尾 2 字节。
+void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
+{
+  uint16_t wCRC = 0u;
+
+  //不向空指针或长度不足的帧缓冲区写入。
+  if ((pchMessage == NULL) || (dwLength <= 2u))
+  {
+    return;
+  }
+
+  //小端协议：低字节在前，高字节在后。
+  wCRC = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
+  pchMessage[dwLength - 2u] = (uint8_t)(wCRC & 0x00ffu);
+  pchMessage[dwLength - 1u] = (uint8_t)((wCRC >> 8u) & 0x00ffu);
+}
+
+
+```
+
+
+protocol_frame.c
+
+```c
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "crc_ref.h"
+
+#define FRAME_START_BYTE 0xA5u /* 固定帧头，用于接收端寻找一帧的开始。 */
+#define FRAME_CRC16_SIZE 2u    /* CRC16 占两个线上字节。 */
+
+/*
+ * 线上帧格式（所有偏移量均相对于 protocol_frame_t 起始地址）：
+ *
+ *   偏移 0       start              帧头，1 字节
+ *   偏移 1       type               所属分类，1 字节
+ *   偏移 2..3    payload_length     payload 长度，2 字节，小端序
+ *   偏移 4..7    timestamp          时间戳，4 字节，小端序
+ *   偏移 8       header_crc8        帧头 CRC8，1 字节
+ *   偏移 9..     payload            可变长度的业务数据
+ *   最后 2 字节  crc16              整帧 CRC16，低字节在前
+ *
+ * payload 是协议中的可变长度区域。柔性数组成员必须是结构体的最后一个成员，
+ * 因此 CRC16 尾部通过同一次分配的额外空间放在 payload 后面。多字节字段使用
+ * 字节数组保存，再显式按协议字节序读写，避免结构体填充和主机字节序影响线上格式。
+ */
+typedef struct {
+    uint8_t start;
+    uint8_t type;
+    uint8_t payload_length[2];
+    uint8_t timestamp[4];
+    uint8_t header_crc8;
+    uint8_t payload[];
+} protocol_frame_t;
+
+enum {
+    FRAME_START_OFFSET = offsetof(protocol_frame_t, start), // 帧头偏移
+    FRAME_TYPE_OFFSET = offsetof(protocol_frame_t, type), // 帧类型偏移
+    FRAME_PAYLOAD_LENGTH_OFFSET = offsetof(protocol_frame_t, payload_length), // 帧负载长度偏移
+    FRAME_TIMESTAMP_OFFSET = offsetof(protocol_frame_t, timestamp), // 时间戳偏移
+    FRAME_HEADER_CRC8_OFFSET = offsetof(protocol_frame_t, header_crc8), // 帧头 CRC8 偏移
+    FRAME_PAYLOAD_OFFSET = offsetof(protocol_frame_t, payload), // 可变长度数据的偏移
+    FRAME_HEADER_SIZE = offsetof(protocol_frame_t, payload) // 固定线上帧头长度
+};
+
+/*
+ * 按指定字节序把 16 位整数写入线上缓冲区。
+ *
+ * big_endian == true：大端序，高字节在前；
+ * big_endian == false：小端序，低字节在前。
+ * C 语言没有可省略的默认参数，因此 false 是调用者应使用的默认选择，
+ * 必须在调用处显式传入。当前协议的调用点统一传入 false，使用小端序。
+ */
+static void write_u16(uint8_t *destination, uint16_t value,
+                         bool big_endian) {
+    if (big_endian) {
+        destination[0] = (uint8_t)(value >> 8u);
+        destination[1] = (uint8_t)value;
+    } else {
+        destination[0] = (uint8_t)value;
+        destination[1] = (uint8_t)(value >> 8u);
+    }
+}
+
+/* 按 big_endian 选择的字节序把 32 位整数写入线上缓冲区。 */
+static void write_u32(uint8_t *destination, uint32_t value,
+                         bool big_endian) {
+    if (big_endian) {
+        destination[0] = (uint8_t)(value >> 24u);
+        destination[1] = (uint8_t)(value >> 16u);
+        destination[2] = (uint8_t)(value >> 8u);
+        destination[3] = (uint8_t)value;
+    } else {
+        destination[0] = (uint8_t)value;
+        destination[1] = (uint8_t)(value >> 8u);
+        destination[2] = (uint8_t)(value >> 16u);
+        destination[3] = (uint8_t)(value >> 24u);
+    }
+}
+
+/* 按 big_endian 选择的字节序从线上缓冲区读取 16 位整数。 */
+static uint16_t read_u16(const uint8_t *source, bool big_endian) {
+    if (big_endian) {
+        return (uint16_t)(((uint16_t)source[0] << 8u) |
+                          (uint16_t)source[1]);
+    }
+
+    return (uint16_t)((uint16_t)source[0] |
+                      ((uint16_t)source[1] << 8u));
+}
+
+/* 按 big_endian 选择的字节序从线上缓冲区读取 32 位整数。 */
+static uint32_t read_u32(const uint8_t *source, bool big_endian) {
+    if (big_endian) {
+        return ((uint32_t)source[0] << 24u) |
+               ((uint32_t)source[1] << 16u) |
+               ((uint32_t)source[2] << 8u) |
+               (uint32_t)source[3];
+    }
+
+    return (uint32_t)source[0] |
+           ((uint32_t)source[1] << 8u) |
+           ((uint32_t)source[2] << 16u) |
+           ((uint32_t)source[3] << 24u);
+}
+
+/*
+ * 组装一帧完整的线上数据。
+ *
+ * 函数先检查长度和指针，再分配空间；之后按协议序列化字段、复制 payload，
+ * 最后计算 CRC8 和 CRC16。这样 CRC 覆盖的是最终真正要发送的字节。
+ */
+static int data_process(uint8_t type, uint32_t timestamp,
+                        const uint8_t *payload, size_t payload_size,
+                        protocol_frame_t **frame_out,
+                        uint32_t *frame_size_out) {
+    size_t calculated_frame_size;//计算的帧大小
+    protocol_frame_t *frame;//分配的帧缓冲区
+
+    /* 输出参数无效时不能写回结果。 */
+    if ((frame_out == NULL) || (frame_size_out == NULL)) {
+        return FALSE;
+    }
+
+    *frame_out = NULL;
+    *frame_size_out = 0u;
+
+    /* payload_length 只有 16 位，超出后强制转换会发生截断。 */
+    if (payload_size > UINT16_MAX) {
+        fputs("Payload is too large for the 16-bit length field.\n", stderr);
+        return FALSE;
+    }
+    /* 只有空 payload 才允许 payload 指针为 NULL。 */
+    if ((payload == NULL) && (payload_size != 0u)) {
+        fputs("Payload pointer is NULL for a non-empty payload.\n", stderr);
+        return FALSE;
+    }
+    /* 先检查加法，再计算总长度，防止 size_t 溢出。 */
+    if (payload_size > SIZE_MAX - sizeof(protocol_frame_t) - FRAME_CRC16_SIZE) {
+        fputs("Frame size calculation overflowed size_t.\n", stderr);
+        return FALSE;
+    }
+
+    calculated_frame_size =
+        sizeof(protocol_frame_t) + payload_size + FRAME_CRC16_SIZE;
+    /* payload_size 已限制为 uint16_t，故完整帧最大为 65546 字节，可安全转为 uint32_t。 */
+
+    frame = calloc(1u, calculated_frame_size);
+    if (frame == NULL) {
+        fputs("Failed to allocate protocol frame.\n", stderr);
+        return FALSE;
+    }
+
+    /* 写入固定字段：多字节普通字段统一使用小端序。 */
+    frame->start = FRAME_START_BYTE;
+    frame->type = type;
+    /* 协议规定 payload_length 使用小端序，因此这里明确传入 false。 */
+    write_u16(frame->payload_length, (uint16_t)payload_size, false);
+    /* 协议规定 timestamp 使用小端序，因此这里明确传入 false。 */
+    write_u32(frame->timestamp, timestamp, false);
+    frame->header_crc8 = 0u;
+
+    /* payload 是可变长度区域，紧接在固定帧头之后。 */
+    if (payload_size != 0u) {
+        memcpy(frame->payload, payload, payload_size);
+    }
+
+    /* CRC8 覆盖前 8 个帧头字节，并把结果写入偏移 8。 */
+    Append_CRC8_Check_Sum((uint8_t *)frame, (uint16_t)FRAME_HEADER_SIZE);
+    /* CRC16 计算覆盖帧头和 payload；计算结果写入帧尾预留的两个 CRC16 字节。 */
+    Append_CRC16_Check_Sum((uint8_t *)frame, (uint32_t)calculated_frame_size);
+
+    *frame_out = frame;
+    *frame_size_out = (uint32_t)calculated_frame_size;
+    return TRUE;
+}
+
+static void print_layout(void) {
+    printf("start offset:          %zu\n", (size_t)FRAME_START_OFFSET);
+    printf("type offset:           %zu\n", (size_t)FRAME_TYPE_OFFSET);
+    printf("payload_length offset: %zu\n", (size_t)FRAME_PAYLOAD_LENGTH_OFFSET);
+    printf("timestamp offset:      %zu\n", (size_t)FRAME_TIMESTAMP_OFFSET);
+    printf("header_crc8 offset:    %zu\n", (size_t)FRAME_HEADER_CRC8_OFFSET);
+    printf("payload offset:        %zu\n", (size_t)FRAME_PAYLOAD_OFFSET);
+}
+
+int main(void) {
+    uint8_t crc_test_vector[] = "123456789";
+    /* 示例 payload；实际项目中可替换为待发送的业务数据。 */
+    const uint8_t sample_payload[] = {0x10u, 0x20u, 0x30u, 0x40u};
+    const size_t payload_size = sizeof(sample_payload);
+    protocol_frame_t *frame = NULL;
+    uint32_t frame_size = 0u;
+    const uint8_t *crc16;
+
+    /* type=0x01 表示一个示例业务分类，时间戳固定为 0x12345678。 */
+    if (data_process(0x01u, 0x12345678u, sample_payload,
+                     payload_size, &frame, &frame_size) != TRUE) {
+        return EXIT_FAILURE;
+    }
+
+    /* CRC16 位于 payload 后面，因此它的起始偏移随 payload 长度变化。 */
+    crc16 = &frame->payload[payload_size];
+
+    /* 固定测试向量锁定当前 CRC 参数，防止查找表或初值被误改。 */
+    if ((Get_CRC8_Check_Sum(crc_test_vector, 9u, 0xffu) != 0x0bu) ||
+        (Get_CRC16_Check_Sum(crc_test_vector, 9u, 0xffffu) != 0x6f91u)) {
+        fputs("CRC test vector check failed.\n", stderr);
+        free(frame);
+        return EXIT_FAILURE;
+    }
+
+    print_layout();
+    printf("CRC test vector:       passed (CRC-8=0x0B, CRC-16=0x6F91)\n");
+    printf("crc16 offset:          %u\n",
+           (unsigned int)(crc16 - (const uint8_t *)frame));
+    printf("total frame size:      %u bytes\n", (unsigned int)frame_size);
+    /* 通过解码函数读取线上字段，验证字节序与数值均正确。 */
+    printf("payload length:        %u\n",
+           (unsigned int)read_u16(frame->payload_length, false));
+    printf("timestamp:             0x%08X\n",
+           (unsigned int)read_u32(frame->timestamp, false));
+    printf("timestamp wire bytes:  %02X %02X %02X %02X\n",
+           (unsigned int)frame->timestamp[0],
+           (unsigned int)frame->timestamp[1],
+           (unsigned int)frame->timestamp[2],
+           (unsigned int)frame->timestamp[3]);
+    printf("crc8 check:            %s\n",
+           Verify_CRC8_Check_Sum((uint8_t *)frame,
+                                 (uint16_t)FRAME_HEADER_SIZE) == TRUE
+               ? "passed"
+               : "failed");
+    printf("crc16 check:           %s\n",
+           Verify_CRC16_Check_Sum((uint8_t *)frame, frame_size) == TRUE
+               ? "passed"
+               : "failed");
+
+    free(frame);
+    return EXIT_SUCCESS;
+}
+
+
+```
+
+把三个文件放在同一目录后编译运行：
+
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic protocol_frame.c crc_ref.c -o protocol_frame && ./protocol_frame
+```
+
+这组测试数据的输出如下：
+
+```text
+start offset:          0
+type offset:           1
+payload_length offset: 2
+timestamp offset:      4
+header_crc8 offset:    8
+payload offset:        9
+CRC test vector:       passed (CRC-8=0x0B, CRC-16=0x6F91)
+crc16 offset:          13
+total frame size:      15 bytes
+payload length:        4
+timestamp:             0x12345678
+timestamp wire bytes:  78 56 34 12
+crc8 check:            passed
+crc16 check:           passed
+```
+
+这里没有把 `uint16_t` 或 `uint32_t` 直接塞进线上结构体，而是把多字节字段保存成字节数组，再由 `write_u16`、`write_u32` 明确序列化；当前协议调用它们时传入 `false`，固定使用小端序。这样结构体填充和主机字节序都不会偷偷改变协议格式，接收端也能用对应的读取函数还原数值。
+
+固定线上帧头长度取 `offsetof(protocol_frame_t, payload)`，而不是把 `sizeof(protocol_frame_t)` 当成协议长度。柔性数组成员本身不计入 `sizeof`，但标准允许结构体在末尾保留额外填充；用成员偏移计算线上头长，才能准确找到 payload 真正开始的位置。分配内存时仍使用 `sizeof(protocol_frame_t)`，这样连同可能的尾部填充也有足够空间；CRC16 则放在同一次分配中、紧跟 payload 的两个额外字节里。
+
+> ⚠️ **踩坑预警**
+> CRC 不只是一个“CRC16”名字：多项式、初值、输入/输出反射、最终异或值和线上字节序共同决定结果。本例的 CRC-8 使用多项式 `0x31`、初值 `0xFF`、反射输入/输出、最终异或值 `0x00`；CRC-16 使用多项式 `0x1021`、初值 `0xFFFF`、反射输入/输出、最终异或值 `0x0000`，并按小端写入帧尾。`"123456789"` 的固定测试结果分别为 `0x0B` 和 `0x6F91`，用于防止示例内部参数被误改；接入真实设备时，仍必须同协议文档或设备给出的测试帧逐项核对，不能只看位数相同就直接复用。
+
+:::
+
 ## 参考资源
 
 - [C struct - cppreference](https://en.cppreference.com/w/c/language/struct)
-- [C11 alignas/alignof - cppreference](https://en.cppreference.com/w/c/language/alignment)
+- [C11 alignas/alignof - cppreference](https://en.cppreference.com/w/c/language/_Alignas)
 - [offsetof - cppreference](https://en.cppreference.com/w/c/types/offsetof)
 - [Flexible array members - cppreference](https://en.cppreference.com/w/c/language/struct)

--- a/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
+++ b/documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md
@@ -533,7 +533,7 @@ int main(void)
 ```
 
 ```bash
-gcc -std=c17 -Wall -Wextra alignment_verify.c -o alignment_verify && ./alignment_verify
+gcc -std=c17 -Wall -Wextra -Wpedantic alignment_verify.c -o alignment_verify && ./alignment_verify
 ```
 
 在 `int` 为 4 字节、按 4 字节对齐的测试环境中，输出如下：
@@ -625,7 +625,7 @@ int main(void)
 ```
 
 ```bash
-gcc -std=c17 -Wall -Wextra packed_compare.c -o packed_compare && ./packed_compare
+gcc -std=c17 -Wall -Wextra -Wpedantic packed_compare.c -o packed_compare && ./packed_compare
 ```
 
 运行结果：
@@ -664,23 +664,21 @@ FrameAligned: type=0, value=4, sizeof=8
 
 ::: details 参考答案
 
+题面只要求预留校验字段，下面给出一份完整的 CRC8/CRC16 与协议帧实现，供学有余力的读者对照。完整程序分为三个文件：
 
-
-crc_ref.h
+**crc_ref.h**
 
 ```c
 #ifndef CRC_REF_H
 #define CRC_REF_H
 
 #include <stdint.h>
-
-#define TRUE 1u
-#define FALSE 0u
+#include <stdbool.h>
 
 
 void Append_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
 
-uint32_t Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
+bool Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength);
 
 
 uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
@@ -690,7 +688,7 @@ uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
 void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
 
 
-uint32_t Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
+bool Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength);
 
 
 uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
@@ -701,13 +699,15 @@ uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
 
 ```
 
-crc_ref.c
+**crc_ref.c**
 
 ```c
 
 #include "crc_ref.h"
 
 #include <stddef.h>
+
+/* CRC 查表和接口命名改编自 RoboMaster 官方例程；为便于对照保留原命名。 */
 
 
 //查表法CRC
@@ -784,7 +784,7 @@ uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
 {
   uint8_t ucIndex = 0u;
 
-  //? 每轮消耗 1 字节，并把该字节折叠进当前 CRC 状态。
+  // 每轮消耗 1 字节，并把该字节折叠进当前 CRC 状态。
   while (dwLength-- != 0u)
   {
     ucIndex = ucCRC8 ^ (*pchMessage++);
@@ -794,20 +794,20 @@ uint8_t Get_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength,
 }
 
 //校验缓冲区末尾已保存的 CRC8。
-uint32_t Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
+bool Verify_CRC8_Check_Sum(uint8_t *pchMessage, uint16_t dwLength)
 {
   uint8_t expected = 0u;
 
   // 系统帧头至少要包含有效字段和 1 字节 CRC8。
   if ((pchMessage == NULL) || (dwLength <= 2u))
   {
-    return FALSE;
+    return false;
   }
 
   //计算窗口排除末尾已经保存的 CRC8 字节。
   expected = Get_CRC8_Check_Sum(pchMessage, (uint16_t)(dwLength - 1u),
                                 k_crc8_init);
-  return (expected == pchMessage[dwLength - 1u]) ? TRUE : FALSE;
+  return expected == pchMessage[dwLength - 1u];
 }
 
 //把重新计算得到的 CRC8 写入缓冲区末尾。
@@ -847,22 +847,20 @@ uint16_t Get_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength,
 
 //校验完整帧末尾 2 字节保存的 CRC16。
 
-uint32_t Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
+bool Verify_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
 {
   uint16_t expected = 0u;
 
   //完整帧至少要包含受保护数据和 2 字节 CRC16。
   if ((pchMessage == NULL) || (dwLength <= 2u))
   {
-    return FALSE;
+    return false;
   }
 
   //只重算受保护的载荷/帧头区域，末尾 CRC16 不参与计算。
   expected = Get_CRC16_Check_Sum(pchMessage, dwLength - 2u, k_crc16_init);
   return (((expected & 0x00ffu) == pchMessage[dwLength - 2u]) &&
-          (((expected >> 8u) & 0x00ffu) == pchMessage[dwLength - 1u]))
-             ? TRUE
-             : FALSE;
+          (((expected >> 8u) & 0x00ffu) == pchMessage[dwLength - 1u]));
 }
 
 //把 CRC16 追加到完整帧缓冲区末尾 2 字节。
@@ -885,8 +883,7 @@ void Append_CRC16_Check_Sum(uint8_t *pchMessage, uint32_t dwLength)
 
 ```
 
-
-protocol_frame.c
+**protocol_frame.c**
 
 ```c
 #include <stdint.h>
@@ -1002,16 +999,16 @@ static uint32_t read_u32(const uint8_t *source, bool big_endian) {
  * 函数先检查长度和指针，再分配空间；之后按协议序列化字段、复制 payload，
  * 最后计算 CRC8 和 CRC16。这样 CRC 覆盖的是最终真正要发送的字节。
  */
-static int data_process(uint8_t type, uint32_t timestamp,
+static bool data_process(uint8_t type, uint32_t timestamp,
                         const uint8_t *payload, size_t payload_size,
                         protocol_frame_t **frame_out,
                         uint32_t *frame_size_out) {
-    size_t calculated_frame_size;//计算的帧大小
-    protocol_frame_t *frame;//分配的帧缓冲区
+    size_t calculated_frame_size; // 计算的帧大小
+    protocol_frame_t *frame; // 分配的帧缓冲区
 
     /* 输出参数无效时不能写回结果。 */
     if ((frame_out == NULL) || (frame_size_out == NULL)) {
-        return FALSE;
+        return false;
     }
 
     *frame_out = NULL;
@@ -1020,17 +1017,17 @@ static int data_process(uint8_t type, uint32_t timestamp,
     /* payload_length 只有 16 位，超出后强制转换会发生截断。 */
     if (payload_size > UINT16_MAX) {
         fputs("Payload is too large for the 16-bit length field.\n", stderr);
-        return FALSE;
+        return false;
     }
     /* 只有空 payload 才允许 payload 指针为 NULL。 */
     if ((payload == NULL) && (payload_size != 0u)) {
         fputs("Payload pointer is NULL for a non-empty payload.\n", stderr);
-        return FALSE;
+        return false;
     }
     /* 先检查加法，再计算总长度，防止 size_t 溢出。 */
     if (payload_size > SIZE_MAX - sizeof(protocol_frame_t) - FRAME_CRC16_SIZE) {
         fputs("Frame size calculation overflowed size_t.\n", stderr);
-        return FALSE;
+        return false;
     }
 
     calculated_frame_size =
@@ -1040,7 +1037,7 @@ static int data_process(uint8_t type, uint32_t timestamp,
     frame = calloc(1u, calculated_frame_size);
     if (frame == NULL) {
         fputs("Failed to allocate protocol frame.\n", stderr);
-        return FALSE;
+        return false;
     }
 
     /* 写入固定字段：多字节普通字段统一使用小端序。 */
@@ -1064,7 +1061,7 @@ static int data_process(uint8_t type, uint32_t timestamp,
 
     *frame_out = frame;
     *frame_size_out = (uint32_t)calculated_frame_size;
-    return TRUE;
+    return true;
 }
 
 static void print_layout(void) {
@@ -1087,7 +1084,7 @@ int main(void) {
 
     /* type=0x01 表示一个示例业务分类，时间戳固定为 0x12345678。 */
     if (data_process(0x01u, 0x12345678u, sample_payload,
-                     payload_size, &frame, &frame_size) != TRUE) {
+                     payload_size, &frame, &frame_size) == false) {
         return EXIT_FAILURE;
     }
 
@@ -1119,11 +1116,11 @@ int main(void) {
            (unsigned int)frame->timestamp[3]);
     printf("crc8 check:            %s\n",
            Verify_CRC8_Check_Sum((uint8_t *)frame,
-                                 (uint16_t)FRAME_HEADER_SIZE) == TRUE
+                                 (uint16_t)FRAME_HEADER_SIZE)
                ? "passed"
                : "failed");
     printf("crc16 check:           %s\n",
-           Verify_CRC16_Check_Sum((uint8_t *)frame, frame_size) == TRUE
+           Verify_CRC16_Check_Sum((uint8_t *)frame, frame_size)
                ? "passed"
                : "failed");
 

--- a/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
+++ b/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
@@ -383,9 +383,9 @@ typedef union {
     uint32_t u;
 } FloatBits;
 
-//float 的 IEEE 754 浮点数位规则
-//1 位符号 |  8 位指数                  |  23 位尾数
-//正还是负 | 决定能表示多大、多小（范围） | 决定有多少位有效数字（精度）
+// float 的 IEEE 754 浮点数位规则
+// 1 位符号 |  8 位指数                  |  23 位尾数
+// 正还是负 | 决定能表示多大、多小（范围） | 决定有多少位有效数字（精度）
 void print_float_bits(float f)
 {
     FloatBits data;
@@ -442,7 +442,7 @@ int main(void)
     /* 缓冲区未读到换行时，确认是否还有未读取的字符，避免静默截断。 */
     if (strchr(input, '\n') == NULL)
     {
-        //读取输入的第32个字符
+        // 读取输入的第 32 个字符
         int next_character = getchar();
 
         if (next_character != '\n' && next_character != EOF)
@@ -468,6 +468,8 @@ int main(void)
 }
 
 ```
+
+编译运行：
 
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic float_bits.c -o float_bits && printf '%s\n' '-3.14' | ./float_bits
@@ -603,6 +605,8 @@ int main(void)
 - `D` = `dma_enable`，占 bit 2
 
 `value` 与 `bits` 共用同一段 32 位存储，因此可用 `value` 观察这些位的整体值。位域的实际分配方向、对齐和填充由实现定义；上图只描述这一示例已实测的 GCC x86_64 布局，不能直接当作跨编译器或跨目标平台的寄存器协议。
+
+编译运行：
 
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic bitfield_register.c -o bitfield_register && ./bitfield_register
@@ -822,6 +826,8 @@ int main(void)
 }
 
 ```
+
+编译运行：
 
 ```bash
 gcc -std=c17 -Wall -Wextra -Wpedantic tagged_union.c -o tagged_union && ./tagged_union

--- a/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
+++ b/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
@@ -463,6 +463,9 @@ int main(void)
         return 1;
     }
 
+    /* 管道或重定向输入没有终端回显，这里回显实际读到的输入行。 */
+    fputs(input, stdout);
+
     print_float_bits(value);
     return 0;
 }

--- a/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
+++ b/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
@@ -383,7 +383,7 @@ typedef union {
     uint32_t u;
 } FloatBits;
 
-//float的IEEE 754 浮点数字节规则
+//float 的 IEEE 754 浮点数位规则
 //1 位符号 |  8 位指数                  |  23 位尾数
 //正还是负 | 决定能表示多大、多小（范围） | 决定有多少位有效数字（精度）
 void print_float_bits(float f)
@@ -485,7 +485,7 @@ bits     = 1 10000000 10010001111010111000011
 ```
 
 > ⚠️ **踩坑预警**
-> `fgets` 对 `char input[32]` 最多读取 31 个字符，并在末尾追加 `\0`。当输入行超过 31 个字符时，函数仍会返回成功，但换行符和剩余内容还留在输入流中；如果不检查 `next_character` 是否为 `\n` 或 `EOF`，即使输入过长仍会判断为为完整读取。
+> `fgets` 对 `char input[32]` 最多读取 31 个字符，并在末尾追加 `\0`。当输入行超过 31 个字符时，函数仍会返回成功，但换行符和剩余内容还留在输入流中；如果不检查 `next_character` 是否为 `\n` 或 `EOF`，即使输入过长仍会判断为完整读取。
 
 :::
 
@@ -657,6 +657,7 @@ int main(void) {
 ```c
 #include <stdio.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 /* 用于标识联合体中当前有效成员的类型标签。 */
 typedef enum {
@@ -736,52 +737,55 @@ void print_tagged_value(const TaggedValue *value)
     }
 }
 
-/* 仅当值实际保存 int 时返回其内容，否则返回 0 并报告错误。 */
-int get_as_int(const TaggedValue *value)
+/* 仅当值实际保存 int 时写入输出参数并返回 true。 */
+bool get_as_int(const TaggedValue *value, int *out)
 {
-    if (value == NULL) {
-        fprintf(stderr, "Error: value is NULL.\n");
-        return 0;
+    if ((value == NULL) || (out == NULL)) {
+        fprintf(stderr, "Error: value or output is NULL.\n");
+        return false;
     }
 
     if (value->tag != TAG_INT) {
         fprintf(stderr, "Error: value is not an int.\n");
-        return 0;
+        return false;
     }
 
-    return value->data.int_value;
+    *out = value->data.int_value;
+    return true;
 }
 
-/* 仅当值实际保存 float 时返回其内容，否则返回 0.0f 并报告错误。 */
-float get_as_float(const TaggedValue *value)
+/* 仅当值实际保存 float 时写入输出参数并返回 true。 */
+bool get_as_float(const TaggedValue *value, float *out)
 {
-    if (value == NULL) {
-        fprintf(stderr, "Error: value is NULL.\n");
-        return 0.0f;
+    if ((value == NULL) || (out == NULL)) {
+        fprintf(stderr, "Error: value or output is NULL.\n");
+        return false;
     }
 
     if (value->tag != TAG_FLOAT) {
         fprintf(stderr, "Error: value is not a float.\n");
-        return 0.0f;
+        return false;
     }
 
-    return value->data.float_value;
+    *out = value->data.float_value;
+    return true;
 }
 
-/* 仅当值实际保存字符串指针时返回该指针，否则返回 NULL 并报告错误。 */
-const char *get_as_string(const TaggedValue *value)
+/* 仅当值实际保存字符串指针时写入输出参数并返回 true。 */
+bool get_as_string(const TaggedValue *value, const char **out)
 {
-    if (value == NULL) {
-        fprintf(stderr, "Error: value is NULL.\n");
-        return NULL;
+    if ((value == NULL) || (out == NULL)) {
+        fprintf(stderr, "Error: value or output is NULL.\n");
+        return false;
     }
 
     if (value->tag != TAG_STRING) {
         fprintf(stderr, "Error: value is not a string.\n");
-        return NULL;
+        return false;
     }
 
-    return value->data.string_value;
+    *out = value->data.string_value;
+    return true;
 }
 
 int main(void)
@@ -790,7 +794,9 @@ int main(void)
     TaggedValue int_value = make_int(42);
     TaggedValue float_value = make_float(3.14f);
     TaggedValue string_value = make_string("Hello, tagged union!");
-    const char *text;
+    int int_result = 0;
+    float float_result = 0.0f;
+    const char *text = NULL;
 
     /* 输出时由类型标签决定应读取联合体的哪个成员。 */
     print_tagged_value(&int_value);
@@ -798,16 +804,19 @@ int main(void)
     print_tagged_value(&string_value);
 
     /* 通过类型匹配的访问函数读取数据。 */
-    printf("get_as_int: %d\n", get_as_int(&int_value));
-    printf("get_as_float: %.2f\n", get_as_float(&float_value));
-    text = get_as_string(&string_value);
-    if (text != NULL) {
+    if (get_as_int(&int_value, &int_result)) {
+        printf("get_as_int: %d\n", int_result);
+    }
+    if (get_as_float(&float_value, &float_result)) {
+        printf("get_as_float: %.2f\n", float_result);
+    }
+    if (get_as_string(&string_value, &text)) {
         printf("get_as_string: %s\n", text);
     }
 
     /* 以下两次调用用于演示类型不匹配时的错误处理。 */
-    (void)get_as_float(&int_value);
-    (void)get_as_string(&float_value);
+    (void)get_as_float(&int_value, &float_result);
+    (void)get_as_string(&float_value, &text);
 
     return 0;
 }
@@ -831,11 +840,11 @@ Error: value is not a float.
 Error: value is not a string.
 ```
 
-`TaggedValue` 的 `tag` 和 `data` 必须一起维护：写入 `data.float_value` 后，只有 `tag == kValueTagFloat` 时才可以读取它。`make_string` 只保存指针，不复制字符串，因此调用方必须保证字符串的存储期覆盖整个使用过程；这里用 `bool` 加输出参数表示访问结果，也避免把合法的 `0`、`0.0f` 或 `NULL` 与错误混为一谈。
+`TaggedValue` 的 `tag` 和 `data` 必须一起维护：写入 `data.float_value` 后，只有 `tag == TAG_FLOAT` 时才可以读取它。`make_string` 只保存指针，不复制字符串，因此调用方必须保证字符串的存储期覆盖整个使用过程；三个 `get_as_*` 函数用 `bool` 加输出参数表示访问结果，避免把合法的 `0`、`0.0f` 或 `NULL` 与错误混为一谈。
 
 :::
 
 ## 参考资源
 
 - [cppreference：C union](https://en.cppreference.com/w/c/language/union)、[C enumeration](https://en.cppreference.com/w/c/language/enum)、[C bit-field](https://en.cppreference.com/w/c/language/bit_field)：C 语言规则与实现差异速查。
-- [cppreference：`std::variant`](https://en.cppreference.com/w/cpp/utility/variant)、[`std::bitset`](https://en.cppreference.com/w/cpp/utility/bitset)、[`std::bit_cast`](https://en.cppreference.com/w/cpp/numeric/bit_cast)：C++11/17/20 对应工具。
+- [cppreference：`std::variant`](https://en.cppreference.com/w/cpp/utility/variant)（C++17）、[`std::bitset`](https://en.cppreference.com/w/cpp/utility/bitset)（C++98）、[`std::bit_cast`](https://en.cppreference.com/w/cpp/numeric/bit_cast)（C++20）：对应工具。

--- a/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
+++ b/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
@@ -4,13 +4,14 @@ cpp_standard:
 - 11
 - 14
 - 17
+- 20
 description: 掌握联合体、枚举、位域与 typedef 的使用，理解类型双关、硬件寄存器映射等技巧，对比 C++ 的类型安全替代方案
 difficulty: beginner
 order: 17
 platform: host
 prerequisites:
 - 12 结构体与内存对齐
-reading_time_minutes: 11
+reading_time_minutes: 22
 tags:
 - host
 - cpp-modern
@@ -72,7 +73,7 @@ int main(void) {
 sizeof(IntUnion) = 4
 ```
 
-`IntUnion` 的大小是 4 字节——由最大的成员 `uint32_t` 决定。`u8`、`u16`、`u32` 三个成员的起始地址完全相同，写入其中一个就会覆盖其他的。
+在当前 GCC x86_64 环境中，`IntUnion` 的大小是 4 字节。`u8`、`u16`、`u32` 三个成员的起始地址完全相同；写入某个成员后，其他成员看到的也是这块重叠存储中的字节，而不是三份彼此独立的数据。
 
 > ⚠️ **踩坑预警**：联合体在同一时刻只有**一个**成员是有效的。写入一个成员后再读取另一个成员，在 C 标准中属于未定义行为（除了类型双关的例外）。你必须自己记住当前哪个成员是活跃的，编译器不会帮你检查。
 
@@ -185,7 +186,7 @@ Color c = 42;          // 合法！但 42 不是任何枚举值
 int x = kColorRed;     // 合法！隐式转为 int
 ```
 
-这种宽松在 C 语言看来是"灵活性"，但从类型安全的角度看就是灾难——编译器完全没办法帮你检查"这个值是不是合法的枚举值"。这也是 C++ 引入 `enum class` 的根本原因。
+这种宽松在 C 语言看来是"灵活性"，但从类型安全的角度看就是灾难——编译器完全没办法帮你检查"这个值是不是合法的枚举值"。这也是 C++11 引入 `enum class` 的根本原因。
 
 ## 第三步——用位域按位分配内存
 
@@ -370,6 +371,125 @@ int main(void) {
 }
 ```
 
+::: details 参考答案
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef union {
+    float f;
+    uint32_t u;
+} FloatBits;
+
+//float的IEEE 754 浮点数字节规则
+//1 位符号 |  8 位指数                  |  23 位尾数
+//正还是负 | 决定能表示多大、多小（范围） | 决定有多少位有效数字（精度）
+void print_float_bits(float f)
+{
+    FloatBits data;
+    data.f = f;
+
+    uint32_t sign = (data.u >> 31) & 0x1;
+    uint32_t exponent = (data.u >> 23) & 0xff;
+    uint32_t fraction = data.u & 0x7fffff;
+
+    printf("float = %f\n", f);
+
+    printf("bits     = ");
+    for (int i = 31; i >= 0; --i)
+    {
+        printf("%u", (unsigned int)((data.u >> i) & 1u));
+        if (i == 31 || i == 23)
+        {
+            printf(" ");
+        }
+    }
+    printf("\n");
+
+    printf("1 位符号     = %u\n", (unsigned int)sign);
+    printf("8 位指数 = ");
+    for (int i = 7; i >= 0; --i)
+    {
+        printf("%u", (unsigned int)((exponent >> i) & 1u));
+    }
+    printf("\n");
+
+    printf("23 位尾数 = ");
+    for (int i = 22; i >= 0; --i)
+    {
+        printf("%u", (unsigned int)((fraction >> i) & 1u));
+    }
+    printf("\n");
+}
+
+int main(void)
+{
+    char input[32] = {0};
+    char trailing_character;
+    float value = 0.0f;
+
+    printf("请输入 float：");
+    fflush(stdout);
+
+    if (fgets(input, sizeof(input), stdin) == NULL)
+    {
+        fputs("读取输入失败。\n", stderr);
+        return 1;
+    }
+
+    /* 缓冲区未读到换行时，确认是否还有未读取的字符，避免静默截断。 */
+    if (strchr(input, '\n') == NULL)
+    {
+        //读取输入的第32个字符
+        int next_character = getchar();
+
+        if (next_character != '\n' && next_character != EOF)
+        {
+            while (next_character != '\n' && next_character != EOF)
+            {
+                next_character = getchar();
+            }
+            fputs("输入过长。\n", stderr);
+            return 1;
+        }
+    }
+
+    /* 第二个转换项用于拒绝数字后仍含有非空白字符的输入。 */
+    if (sscanf(input, "%f %c", &value, &trailing_character) != 1)
+    {
+        printf("输入无效！\n");
+        return 1;
+    }
+
+    print_float_bits(value);
+    return 0;
+}
+
+```
+
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic float_bits.c -o float_bits && printf '%s\n' '-3.14' | ./float_bits
+```
+
+在支持 IEEE 754 binary32 的 GCC x86_64 环境中，输入 `-3.14` 的结果如下：
+
+```text
+请输入 float：-3.14
+float = -3.140000
+bits     = 1 10000000 10010001111010111000011
+1 位符号     = 1
+8 位指数 = 10000000
+23 位尾数 = 10010001111010111000011
+```
+
+> ⚠️ **踩坑预警**
+> `fgets` 对 `char input[32]` 最多读取 31 个字符，并在末尾追加 `\0`。当输入行超过 31 个字符时，函数仍会返回成功，但换行符和剩余内容还留在输入流中；如果不检查 `next_character` 是否为 `\n` 或 `EOF`，即使输入过长仍会判断为为完整读取。
+
+:::
+
+
 ### 练习 2：32 位硬件控制寄存器
 
 **难度：基础** · 位域加 union 映射寄存器
@@ -404,6 +524,110 @@ int main(void) {
 }
 ```
 
+::: details 参考答案
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+
+// 位分配：
+//   bit 0:     enable（1 位）
+//   bit 1:     interrupt_enable（1 位）
+//   bit 2:     dma_enable（1 位）
+//   bit 5:3    mode（3 位）
+//   bit 9:6    speed（4 位）
+//   bit 31:10  reserved（22 位）
+typedef union {
+    struct {
+        uint32_t enable : 1;
+        uint32_t interrupt_enable : 1;
+        uint32_t dma_enable : 1;
+        uint32_t mode : 3;
+        uint32_t speed : 4;
+        uint32_t reserved : 22;
+    } bits;
+    uint32_t value;
+} ControlRegister;
+
+void print_register(ControlRegister reg)
+{
+    printf("Register = 0x%08X\n", (unsigned int)reg.value);
+    printf("  enable: %u\n", (unsigned int)reg.bits.enable);
+    printf("  interrupt_enable: %u\n", (unsigned int)reg.bits.interrupt_enable);
+    printf("  dma_enable: %u\n", (unsigned int)reg.bits.dma_enable);
+    printf("  mode: %u\n", (unsigned int)reg.bits.mode);
+    printf("  speed: %u\n", (unsigned int)reg.bits.speed);
+}
+
+void set_mode(ControlRegister *reg, uint32_t mode)
+{
+    if (reg == NULL) {
+        return;
+    }
+
+    // mode 仅占 3 位，因此只保留参数的低 3 位。
+    reg->bits.mode = mode & 0x7U;
+}
+
+int main(void)
+{
+    ControlRegister reg = {0};
+
+    reg.bits.enable = 1U;
+    reg.bits.interrupt_enable = 1U;
+    reg.bits.dma_enable = 0U;
+    reg.bits.speed = 10U;
+    set_mode(&reg, 5U);
+
+    print_register(reg);
+    // 9:1001(取低 3 位)
+    set_mode(&reg, 9U); // 9 被截断为 3 位数值 1。
+    print_register(reg);
+
+    return 0;
+}
+```
+
+在本例的 GCC x86_64 布局中，声明顺序从低位向高位分配；从 32 位整数的高位到低位看，布局如下：
+
+```text
+位编号  31                  10 9       6 5       3   2   1   0
+       +-----------------------+---------+-------+---+---+---+
+字段   |     reserved (22)     | speed 4 | mode 3| D | I | E |
+       +-----------------------+---------+-------+---+---+---+
+位范围          [31:10]            [9:6]    [5:3]  2    1   0
+```
+
+- `E` = `enable`，占 bit 0
+- `I` = `interrupt_enable`，占 bit 1
+- `D` = `dma_enable`，占 bit 2
+
+`value` 与 `bits` 共用同一段 32 位存储，因此可用 `value` 观察这些位的整体值。位域的实际分配方向、对齐和填充由实现定义；上图只描述这一示例已实测的 GCC x86_64 布局，不能直接当作跨编译器或跨目标平台的寄存器协议。
+
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic bitfield_register.c -o bitfield_register && ./bitfield_register
+```
+
+在 WSL Ubuntu 24.04（GCC 13.3，x86_64）中运行：
+
+```text
+Register = 0x000002AB
+  enable: 1
+  interrupt_enable: 1
+  dma_enable: 0
+  mode: 5
+  speed: 10
+Register = 0x0000028B
+  enable: 1
+  interrupt_enable: 1
+  dma_enable: 0
+  mode: 1
+  speed: 10
+```
+
+
+:::
+
 ### 练习 3：简单的 tagged union
 
 **难度：基础** · enum 加 union 加 tag 检查
@@ -427,3 +651,191 @@ int main(void) {
     return 0;
 }
 ```
+
+::: details 参考答案
+
+```c
+#include <stdio.h>
+#include <stdint.h>
+
+/* 用于标识联合体中当前有效成员的类型标签。 */
+typedef enum {
+    TAG_INT,
+    TAG_FLOAT,
+    TAG_STRING
+} ValueTag;
+
+/*
+ * 联合体的所有成员共用同一块存储空间。
+ * 读取时必须根据 ValueTag 选择与最后一次写入相对应的成员。
+ */
+typedef union {
+    int int_value;
+    float float_value;
+    const char *string_value;
+} ValueData;
+
+/* 将类型标签与实际数据绑定，构成一个可存放多种类型的值。 */
+typedef struct {
+    ValueTag tag;
+    ValueData data;
+} TaggedValue;
+
+/* 构造一个保存 int 的带标签值。 */
+TaggedValue make_int(int value)
+{
+    TaggedValue result = { TAG_INT, { .int_value = value } };
+    return result;
+}
+
+/* 构造一个保存 float 的带标签值。 */
+TaggedValue make_float(float value)
+{
+    TaggedValue result = { TAG_FLOAT, { .float_value = value } };
+    return result;
+}
+
+/*
+ * 构造一个保存字符串指针的带标签值。
+ * 该函数不会复制字符串，调用方必须保证字符串在使用期间仍然有效。
+ */
+TaggedValue make_string(const char *value)
+{
+    TaggedValue result = { TAG_STRING, { .string_value = value } };
+    return result;
+}
+
+/* 根据类型标签，以对应的格式输出当前有效成员。 */
+void print_tagged_value(const TaggedValue *value)
+{
+    /* 防止调用方传入空指针后解引用。 */
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return;
+    }
+
+    switch (value->tag) {
+    case TAG_INT:
+        printf("int: %d\n", value->data.int_value);
+        break;
+    case TAG_FLOAT:
+        printf("float: %.2f\n", value->data.float_value);
+        break;
+    case TAG_STRING:
+        /* %s 的实参不能是空指针，避免未定义行为。 */
+        if (value->data.string_value == NULL) {
+            fprintf(stderr, "Error: string value is NULL.\n");
+            return;
+        }
+        printf("string: %s\n", value->data.string_value);
+        break;
+    default:
+        /* 标签被破坏或未按约定初始化时，禁止读取联合体成员。 */
+        fprintf(stderr, "Error: unknown value tag.\n");
+        break;
+    }
+}
+
+/* 仅当值实际保存 int 时返回其内容，否则返回 0 并报告错误。 */
+int get_as_int(const TaggedValue *value)
+{
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return 0;
+    }
+
+    if (value->tag != TAG_INT) {
+        fprintf(stderr, "Error: value is not an int.\n");
+        return 0;
+    }
+
+    return value->data.int_value;
+}
+
+/* 仅当值实际保存 float 时返回其内容，否则返回 0.0f 并报告错误。 */
+float get_as_float(const TaggedValue *value)
+{
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return 0.0f;
+    }
+
+    if (value->tag != TAG_FLOAT) {
+        fprintf(stderr, "Error: value is not a float.\n");
+        return 0.0f;
+    }
+
+    return value->data.float_value;
+}
+
+/* 仅当值实际保存字符串指针时返回该指针，否则返回 NULL 并报告错误。 */
+const char *get_as_string(const TaggedValue *value)
+{
+    if (value == NULL) {
+        fprintf(stderr, "Error: value is NULL.\n");
+        return NULL;
+    }
+
+    if (value->tag != TAG_STRING) {
+        fprintf(stderr, "Error: value is not a string.\n");
+        return NULL;
+    }
+
+    return value->data.string_value;
+}
+
+int main(void)
+{
+    /* 分别创建三种不同类型的带标签值。 */
+    TaggedValue int_value = make_int(42);
+    TaggedValue float_value = make_float(3.14f);
+    TaggedValue string_value = make_string("Hello, tagged union!");
+    const char *text;
+
+    /* 输出时由类型标签决定应读取联合体的哪个成员。 */
+    print_tagged_value(&int_value);
+    print_tagged_value(&float_value);
+    print_tagged_value(&string_value);
+
+    /* 通过类型匹配的访问函数读取数据。 */
+    printf("get_as_int: %d\n", get_as_int(&int_value));
+    printf("get_as_float: %.2f\n", get_as_float(&float_value));
+    text = get_as_string(&string_value);
+    if (text != NULL) {
+        printf("get_as_string: %s\n", text);
+    }
+
+    /* 以下两次调用用于演示类型不匹配时的错误处理。 */
+    (void)get_as_float(&int_value);
+    (void)get_as_string(&float_value);
+
+    return 0;
+}
+
+```
+
+```bash
+gcc -std=c17 -Wall -Wextra -Wpedantic tagged_union.c -o tagged_union && ./tagged_union
+```
+
+运行结果：
+
+```text
+int: 42
+float: 3.14
+string: Hello, tagged union!
+get_as_int: 42
+get_as_float: 3.14
+get_as_string: Hello, tagged union!
+Error: value is not a float.
+Error: value is not a string.
+```
+
+`TaggedValue` 的 `tag` 和 `data` 必须一起维护：写入 `data.float_value` 后，只有 `tag == kValueTagFloat` 时才可以读取它。`make_string` 只保存指针，不复制字符串，因此调用方必须保证字符串的存储期覆盖整个使用过程；这里用 `bool` 加输出参数表示访问结果，也避免把合法的 `0`、`0.0f` 或 `NULL` 与错误混为一谈。
+
+:::
+
+## 参考资源
+
+- [cppreference：C union](https://en.cppreference.com/w/c/language/union)、[C enumeration](https://en.cppreference.com/w/c/language/enum)、[C bit-field](https://en.cppreference.com/w/c/language/bit_field)：C 语言规则与实现差异速查。
+- [cppreference：`std::variant`](https://en.cppreference.com/w/cpp/utility/variant)、[`std::bitset`](https://en.cppreference.com/w/cpp/utility/bitset)、[`std::bit_cast`](https://en.cppreference.com/w/cpp/numeric/bit_cast)：C++11/17/20 对应工具。


### PR DESCRIPTION
## 主要变更

### 1. C 字符串与缓冲区安全

文件：`documents/vol1-fundamentals/c_tutorials/11-c-strings-and-buffer-safety.md`

- 为安全字符串库练习补充 GCC 编译命令。
- 为安全格式化练习补充 GCC 编译命令。
- 为字符串分割练习补充 GCC 编译命令。
- 统一使用 `-std=c11 -Wall -Wextra -Wpedantic` 编译选项。
- 让学习者可以直接根据示例完成编译、运行和输出验证。

### 2. 结构体与内存对齐

文件：`documents/vol1-fundamentals/c_tutorials/12-struct-and-memory-alignment.md`

- 补充结构体成员偏移和整体大小的完整验证程序。
- 使用 `offsetof` 和 `sizeof` 验证不同成员排列方式产生的填充差异。
- 补充普通结构体、`packed` 结构体和 `_Alignas` 显式对齐结构体的对比示例。
- 修正结构体赋值、ABI 对齐和柔性数组成员相关说明。
- 明确说明柔性数组成员按值复制时只复制固定成员，不会复制尾随数据。
- 补充通信协议帧设计参考答案。
- 增加 CRC 校验相关实现和协议数据处理示例。
- 强调 `packed` 只影响布局，不负责字节序转换，也不能自动保证任意缓冲区的访问安全。

### 3. 联合体、枚举、位域与 typedef

文件：`documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md`

- 补充 IEEE 754 浮点数位级分解参考答案。
- 补充 32 位硬件控制寄存器位域映射示例。
- 补充位域读取、修改和打印函数。
- 补充带标签联合体（tagged union）的完整实现。
- 增加不同类型值的构造、打印和安全访问函数。
- 展示错误标签访问时的保护逻辑。
- 帮助学习者理解联合体共享内存、枚举标签和位域寄存器映射之间的关系。

## 学习收益

完成这些补充后，学习者可以：

- 通过编译命令直接验证练习答案；
- 观察数组、结构体和联合体在内存中的实际布局；
- 理解结构体填充、显式对齐和 `packed` 结构体的区别；
- 掌握 C 字符串操作中的边界检查和缓冲区安全问题；
- 将联合体、枚举和位域知识联系到协议解析和硬件寄存器设计场景。

## 验证方式

- [ ] 使用 GCC 编译新增代码示例并确认运行结果符合预期
- [ ] `.venv/bin/python scripts/validate_frontmatter.py`
- [ ] `pnpm build`
- [ ] `markdownlint documents/**/*.md`