### PR TITLE
fix:修复浮点交互输入示例并稳定 Windows 分卷构建

### DIFF
--- a/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
+++ b/documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md
@@ -463,8 +463,6 @@ int main(void)
         return 1;
     }
 
-    /* 管道或重定向输入没有终端回显，这里回显实际读到的输入行。 */
-    fputs(input, stdout);
 
     print_float_bits(value);
     return 0;
@@ -475,7 +473,7 @@ int main(void)
 编译运行：
 
 ```bash
-gcc -std=c17 -Wall -Wextra -Wpedantic float_bits.c -o float_bits && printf '%s\n' '-3.14' | ./float_bits
+gcc -std=c17 -Wall -Wextra -Wpedantic float_bits.c -o float_bits && ./float_bits
 ```
 
 在支持 IEEE 754 binary32 的 GCC x86_64 环境中，输入 `-3.14` 的结果如下：

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -294,12 +294,10 @@ async function buildVolume(task: BuildTask): Promise<string> {
   const volOutput = join(BUILD_TMP, 'output', srcDirName)
   const cachedOutput = join(CACHE_DIR, 'output', srcDirName)
 
-  // If cached, copy from cache and skip build
+  // Cached output can be consumed directly during the serialized merge phase.
   if (task.cached) {
     log(`  ${id}: ✓ cached (unchanged)`)
-    mkdirSync(volOutput, { recursive: true })
-    cpSync(cachedOutput, volOutput, { recursive: true })
-    return volOutput
+    return cachedOutput
   }
 
   const mdCount = countMdFiles(volDocDir)
@@ -336,12 +334,31 @@ async function buildVolume(task: BuildTask): Promise<string> {
   if (!existsSync(volOutput)) throw new Error(`${id}: output dir not found after build`)
   log(`  ${id}: ✓ built in ${elapsed}s (${mdCount} files, ${memMB()})`)
 
-  // Save to cache
-  mkdirSync(join(CACHE_DIR, 'output'), { recursive: true })
-  if (existsSync(cachedOutput)) rmSync(cachedOutput, { recursive: true })
-  cpSync(volOutput, cachedOutput, { recursive: true })
-
   return volOutput
+}
+
+/**
+ * Refresh one private cache entry after all VitePress child processes finish.
+ * Windows can transiently report a just-created nested directory as absent
+ * under concurrent build I/O, so retry only those path-not-found errors.
+ */
+async function saveVolumeToCache(id: string, volOutput: string): Promise<void> {
+  const cachedOutput = join(CACHE_DIR, 'output', id)
+  const attempts = process.platform === 'win32' ? 3 : 1
+  mkdirSync(join(CACHE_DIR, 'output'), { recursive: true })
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    rmSync(cachedOutput, { recursive: true, force: true })
+    try {
+      cpSync(volOutput, cachedOutput, { recursive: true })
+      return
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if ((code !== 'ESRCH' && code !== 'ENOENT') || attempt === attempts) throw error
+      log(`  ${id}: cache copy ${code}, retrying (${attempt}/${attempts})`)
+      await new Promise<void>((resolve) => setTimeout(resolve, 100))
+    }
+  }
 }
 
 /** Run tasks with limited concurrency */
@@ -685,14 +702,24 @@ async function main() {
 
   const searchSources: SearchIndexSource[] = [{ dir: rootOutput, lang: 'mixed' }]
   const newManifest: Manifest = {}
+  const volumeOutputs = new Map<string, string>()
 
   await runParallel(tasks, async (task) => {
     const volOutput = await buildVolume(task)
+    volumeOutputs.set(task.id, volOutput)
+  }, CONCURRENCY)
+
+  // Merge only after every VitePress process has exited. Besides keeping the
+  // final output deterministic, this avoids recursive Windows copies racing
+  // with active volume builds on the same filesystem.
+  for (const task of tasks) {
+    const volOutput = volumeOutputs.get(task.id)
+    if (!volOutput) throw new Error(`${task.id}: build output missing`)
+    if (!task.cached) await saveVolumeToCache(task.id, volOutput)
     searchSources.push({ dir: volOutput, lang: task.lang })
-    // Copy to final dist
     cpSync(volOutput, DIST_FINAL, { recursive: true })
     newManifest[task.id] = { hash: task.cacheKey, timestamp: new Date().toISOString() }
-  }, CONCURRENCY)
+  }
 
   // ── Step 3: Merge search indexes ────────────────────────
   await mergeSearchIndexes(searchSources, DIST_FINAL)


### PR DESCRIPTION
## 修复说明

本 PR 包含两项缺陷修复：

1. 修复 `float_bits` 示例的运行方式。
   - 原命令通过 `printf ... | ./float_bits` 固定传入 `-3.14`，读者无法在终端中自行输入其他 `float` 值。
   - 改为直接运行 `./float_bits`，保留程序原有的 `fgets` 与 `sscanf` 输入校验流程。
   - 移除仅为管道输入回显而添加的 `fputs(input, stdout)`；交互终端本身会回显用户输入，避免重复显示。

2. 修复 Windows 下分卷并行构建时缓存复制偶发 `ESRCH` 的问题。
   - 原流程在各 VitePress 分卷子进程仍运行时，立即递归复制输出到缓存和最终 `dist`。
   - 现将缓存写入和最终产物合并移至所有分卷构建完成后，按固定顺序串行执行。
   - 缓存命中时直接使用缓存目录，不再复制回临时目录。
   - Windows 上缓存复制遇到瞬态 `ESRCH` / `ENOENT` 时，最多重试 3 次，每次间隔 100ms；其他平台保持单次复制行为。

## 修复类型

- [x] 内容勘误
- [x] 示例代码问题
- [x] 构建、CI 或脚本问题

## 影响范围

- `documents/vol1-fundamentals/c_tutorials/13-union-enum-bitfield-typedef.md`
  - 更新 `float_bits` 的交互式运行命令与输出行为。
- `scripts/build.ts`
  - 调整分卷构建后的缓存刷新和 `dist` 合并时序。
  - 增加 Windows 缓存复制瞬态路径错误的有界重试。

## 验证方式

环境：Windows、Node.js `v24.12.0`、pnpm `11.18.0`、MinGW GCC。

- [x] `pnpm check:links`
  - 检查通过，1205 个 Markdown 文件的链接均有效。
- [x] `gcc -std=c17 -Wall -Wextra -Wpedantic`
  - 从文档提取 `float_bits` 示例编译通过。
  - 使用 `-3.14` 输入验证，输出的 IEEE 754 binary32 位模式与文档一致。
- [x] `BUILD_CONCURRENCY=4 pnpm build -- --force`
  - 强制全量构建通过，无 `ESRCH`。
  - 成功生成 36 个缓存条目和 4,520 个站点产物文件。
- [x] `BUILD_CONCURRENCY=4 pnpm build`
  - 缓存命中构建通过，验证缓存目录可被直接合并使用。
- [x] `git diff --check origin/main...HEAD`
  - 通过。
- [x] 正式教程文章已存在于导航与索引中，本次无需调整导航。

## 关联 Issue / Discussion

无。