### PR TITLE
docs(cpp): 补充C++的类型与值类别的练习参考答案

### DIFF
--- a/documents/vol1-fundamentals/ch01/01-basic-types.md
+++ b/documents/vol1-fundamentals/ch01/01-basic-types.md
@@ -563,7 +563,7 @@ sizeof(3.14L) = 16
 >
 > - **C++**：`true` 是 `bool` 字面量，`sizeof(true)` = `sizeof(bool)` = 1。
 > - **C（`<stdbool.h>`，C17 及更早）**：`true` 是宏，展开成 `int` 字面量 `1`，`sizeof(true)` = `sizeof(int)` = 4。
-> - **C（C23）**：`true` 变成真正的关键字 `bool`（即 `_Bool`），`sizeof(true)` = 1。
+> - **C（C23）**：`true` / `false` 成为真正的关键字，类型是 `bool`（即 `_Bool`），`sizeof(true)` = 1。
 
 :::
 

--- a/documents/vol1-fundamentals/ch01/01-basic-types.md
+++ b/documents/vol1-fundamentals/ch01/01-basic-types.md
@@ -11,7 +11,7 @@ order: 1
 platform: host
 prerequisites:
 - 第一个 C++ 程序
-reading_time_minutes: 17
+reading_time_minutes: 22
 tags:
 - cpp-modern
 - host
@@ -375,13 +375,284 @@ long double:   16 字节
 
 写一个程序，打印出所有基本整数类型（`short`、`int`、`long`、`long long` 及其 `unsigned` 版本，加上 `int8_t`、`int16_t`、`int32_t`、`int64_t` 及其 `unsigned` 版本）的 `sizeof` 和通过 `std::numeric_limits` 获取的最小值、最大值。格式化输出，让结果一目了然。
 
+
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+#include <limits>
+#include <cstdint>
+
+int main()
+{
+    std::cout << "=== 完整的大小和范围报告 ===" << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "--- 基本整数类型sizeof汇总 ---" << std::endl;
+    std::cout << "short:          sizeof " << sizeof(short) << " 字节, "
+              << "min " << std::numeric_limits<short>::min() << ", "
+              << "max " << std::numeric_limits<short>::max() << std::endl;
+    std::cout << "unsigned short: sizeof " << sizeof(unsigned short) << " 字节, "
+              << "min " << std::numeric_limits<unsigned short>::min() << ", "
+              << "max " << std::numeric_limits<unsigned short>::max() << std::endl;
+    std::cout << "int:            sizeof " << sizeof(int) << " 字节, "
+              << "min " << std::numeric_limits<int>::min() << ", "
+              << "max " << std::numeric_limits<int>::max() << std::endl;
+    std::cout << "unsigned int:   sizeof " << sizeof(unsigned int) << " 字节, "
+              << "min " << std::numeric_limits<unsigned int>::min() << ", "
+              << "max " << std::numeric_limits<unsigned int>::max() << std::endl;
+    std::cout << "long:           sizeof " << sizeof(long) << " 字节, "
+              << "min " << std::numeric_limits<long>::min() << ", "
+              << "max " << std::numeric_limits<long>::max() << std::endl;
+    std::cout << "unsigned long:  sizeof " << sizeof(unsigned long) << " 字节, "
+              << "min " << std::numeric_limits<unsigned long>::min() << ", "
+              << "max " << std::numeric_limits<unsigned long>::max() << std::endl;
+    std::cout << "long long:      sizeof " << sizeof(long long) << " 字节, "
+              << "min " << std::numeric_limits<long long>::min() << ", "
+              << "max " << std::numeric_limits<long long>::max() << std::endl;
+    std::cout << "unsigned long long: sizeof " << sizeof(unsigned long long) << " 字节, "
+              << "min " << std::numeric_limits<unsigned long long>::min() << ", "
+              << "max " << std::numeric_limits<unsigned long long>::max() << std::endl;
+
+    std::cout << std::endl;
+    std::cout << "--- <cstdint> 固定宽整数类型 ---" << std::endl;
+    std::cout << "int8_t:         sizeof " << sizeof(int8_t) << " 字节, "
+              << "min " << (int)std::numeric_limits<int8_t>::min() << ", "
+              << "max " << (int)std::numeric_limits<int8_t>::max() << std::endl;
+    std::cout << "uint8_t:        sizeof " << sizeof(uint8_t) << " 字节, "
+              << "min " << (unsigned)std::numeric_limits<uint8_t>::min() << ", "
+              << "max " << (unsigned)std::numeric_limits<uint8_t>::max() << std::endl;
+    std::cout << "int16_t:        sizeof " << sizeof(int16_t) << " 字节, "
+              << "min " << std::numeric_limits<int16_t>::min() << ", "
+              << "max " << std::numeric_limits<int16_t>::max() << std::endl;
+    std::cout << "uint16_t:       sizeof " << sizeof(uint16_t) << " 字节, "
+              << "min " << std::numeric_limits<uint16_t>::min() << ", "
+              << "max " << std::numeric_limits<uint16_t>::max() << std::endl;
+    std::cout << "int32_t:        sizeof " << sizeof(int32_t) << " 字节, "
+              << "min " << std::numeric_limits<int32_t>::min() << ", "
+              << "max " << std::numeric_limits<int32_t>::max() << std::endl;
+    std::cout << "uint32_t:       sizeof " << sizeof(uint32_t) << " 字节, "
+              << "min " << std::numeric_limits<uint32_t>::min() << ", "
+              << "max " << std::numeric_limits<uint32_t>::max() << std::endl;
+    std::cout << "int64_t:        sizeof " << sizeof(int64_t) << " 字节, "
+              << "min " << std::numeric_limits<int64_t>::min() << ", "
+              << "max " << std::numeric_limits<int64_t>::max() << std::endl;
+    std::cout << "uint64_t:       sizeof " << sizeof(uint64_t) << " 字节, "
+              << "min " << std::numeric_limits<uint64_t>::min() << ", "
+              << "max " << std::numeric_limits<uint64_t>::max() << std::endl;
+
+    return 0;
+}
+
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+=== 完整的大小和范围报告 ===
+
+--- 基本整数类型sizeof汇总 ---
+short:          sizeof 2 字节, min -32768, max 32767
+unsigned short: sizeof 2 字节, min 0, max 65535
+int:            sizeof 4 字节, min -2147483648, max 2147483647
+unsigned int:   sizeof 4 字节, min 0, max 4294967295
+long:           sizeof 8 字节, min -9223372036854775808, max 9223372036854775807
+unsigned long:  sizeof 8 字节, min 0, max 18446744073709551615
+long long:      sizeof 8 字节, min -9223372036854775808, max 9223372036854775807
+unsigned long long: sizeof 8 字节, min 0, max 18446744073709551615
+
+--- <cstdint> 固定宽整数类型 ---
+int8_t:         sizeof 1 字节, min -128, max 127
+uint8_t:        sizeof 1 字节, min 0, max 255
+int16_t:        sizeof 2 字节, min -32768, max 32767
+uint16_t:       sizeof 2 字节, min 0, max 65535
+int32_t:        sizeof 4 字节, min -2147483648, max 2147483647
+uint32_t:       sizeof 4 字节, min 0, max 4294967295
+int64_t:        sizeof 8 字节, min -9223372036854775808, max 9223372036854775807
+uint64_t:       sizeof 8 字节, min 0, max 18446744073709551615
+```
+
+> ℹ️ **平台说明**:以上为典型 64 位 Linux 平台的结果。在 Windows 上,`long` 与 `unsigned long` 是 4 字节(`long` 范围为 `-2147483648` ~ `2147483647`,`unsigned long` 范围为 `0` ~ `4294967295`),其余类型不变。
+
+:::
+
+
+
 ### 练习二：预测 sizeof 的结果
 
 在看答案之前，先预测一下以下表达式在你的平台上的结果，然后写程序验证：`sizeof('A')`、`sizeof(true)`、`sizeof(3.14)`、`sizeof(3.14f)`、`sizeof(3.14L)`。额外挑战：写一个 `.c` 文件编译为 C 程序，再写一个 `.cpp` 文件编译为 C++ 程序，都打印 `sizeof('A')`，观察结果有什么不同。提示：C++ 中字符字面量 `'A'` 的类型是 `char`（`sizeof` 为 1），而 C 中字符常量 `'A'` 的类型是 `int`（`sizeof` 通常为 4），这是两门语言之间一个微妙但重要的区别。
 
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+
+int main()
+{
+    std::cout << "=== C++: sizeof 表达式验证 ===" << std::endl;
+    std::cout << "sizeof('A')   = " << sizeof('A') << std::endl;
+    std::cout << "sizeof(true)  = " << sizeof(true) << std::endl;
+    std::cout << "sizeof(3.14)  = " << sizeof(3.14) << std::endl;
+    std::cout << "sizeof(3.14f) = " << sizeof(3.14f) << std::endl;
+    std::cout << "sizeof(3.14L) = " << sizeof(3.14L) << std::endl;
+    return 0;
+}
+
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+=== C++: sizeof 表达式验证 ===
+sizeof('A')   = 1
+sizeof(true)  = 1
+sizeof(3.14)  = 8
+sizeof(3.14f) = 4
+sizeof(3.14L) = 16
+```
+
+```c
+#include <stdio.h>
+#include <stdbool.h>
+
+int main(void)
+{
+    printf("=== C: sizeof 表达式验证 ===\n");
+    printf("sizeof('A')   = %zu\n", sizeof('A'));
+    printf("sizeof(true)  = %zu\n", sizeof(true));
+    printf("sizeof(3.14)  = %zu\n", sizeof(3.14));
+    printf("sizeof(3.14f) = %zu\n", sizeof(3.14f));
+    printf("sizeof(3.14L) = %zu\n", sizeof(3.14L));
+    return 0;
+}
+
+```
+
+```bash
+gcc -std=c17 -Wall -Wextra -pedantic main.c -o main && ./main
+```
+
+运行结果:
+
+```text
+=== C: sizeof 表达式验证 ===
+sizeof('A')   = 4
+sizeof(true)  = 4
+sizeof(3.14)  = 8
+sizeof(3.14f) = 4
+sizeof(3.14L) = 16
+```
+
+> ⚠️ **踩坑预警**：`sizeof(char)` 恒为 1 字节，但字符字面量 `'A'` 的类型在两门语言里不一样。同理，布尔字面量 `true` 的类型也随语言 / 标准版本变化：
+>
+> - **C++**：`true` 是 `bool` 字面量，`sizeof(true)` = `sizeof(bool)` = 1。
+> - **C（`<stdbool.h>`，C17 及更早）**：`true` 是宏，展开成 `int` 字面量 `1`，`sizeof(true)` = `sizeof(int)` = 4。
+> - **C（C23）**：`true` 变成真正的关键字 `bool`（即 `_Bool`），`sizeof(true)` = 1。
+
+:::
+
+
+
 ### 练习三：体验浮点精度陷阱
 
 写一个程序，用 `float` 变量从 0 开始，每次加 0.1，加 10 次，然后判断结果是否等于 1.0。再用 `double` 做同样的事情。观察两者的行为差异，并用 `std::setprecision` 打印出每一步累加后的精确值。
+
+
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+#include <iomanip>
+//std::setw  设置字符宽度 只对下一个输出生效，用完即失效
+
+//std::setprecision设置精度  持续有效，直到下次调用改变它
+//默认模式下是有效数字位数（20 位有效数字）。
+//配合 std::fixed 后，变成小数点后位数：std::fixed << std::setprecision(2) → 3.14
+
+int main()
+{
+    std::cout << "=== float: 从 0 开始，每次加 0.1，共 10 次 ===" << std::endl;
+    float f = 0.0f;
+    for (int i = 1; i <= 10; ++i)
+    {
+        f += 0.1f;
+        std::cout << std::setw(2) << i << " 次后 = "
+                  << std::setprecision(20) << f << std::endl;
+    }
+    std::cout << "最终 f == 1.0f ?  " << (f == 1.0f ? "true" : "false")
+              << "   差值 = " << (f - 1.0f) << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "=== double: 从 0 开始，每次加 0.1，共 10 次 ===" << std::endl;
+    double d = 0.0;
+    for (int i = 1; i <= 10; ++i)
+    {
+        d += 0.1;
+        std::cout << std::setw(2) << i << " 次后 = "
+                  << std::setprecision(20) << d << std::endl;
+    }
+    std::cout << "最终 d == 1.0 ?  " << (d == 1.0 ? "true" : "false")
+              << "   差值 = " << std::setprecision(20) << (d - 1.0) << std::endl;
+
+    return 0;
+}
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+=== float: 从 0 开始，每次加 0.1，共 10 次 ===
+ 1 次后 = 0.10000000149011611938
+ 2 次后 = 0.20000000298023223877
+ 3 次后 = 0.30000001192092895508
+ 4 次后 = 0.40000000596046447754
+ 5 次后 = 0.5
+ 6 次后 = 0.60000002384185791016
+ 7 次后 = 0.70000004768371582031
+ 8 次后 = 0.80000007152557373047
+ 9 次后 = 0.90000009536743164062
+10 次后 = 1.0000001192092895508
+最终 f == 1.0f ?  false   差值 = 1.1920928955078125e-07
+
+=== double: 从 0 开始，每次加 0.1，共 10 次 ===
+ 1 次后 = 0.10000000000000000555
+ 2 次后 = 0.2000000000000000111
+ 3 次后 = 0.30000000000000004441
+ 4 次后 = 0.4000000000000000222
+ 5 次后 = 0.5
+ 6 次后 = 0.5999999999999999778
+ 7 次后 = 0.69999999999999995559
+ 8 次后 = 0.79999999999999993339
+ 9 次后 = 0.89999999999999991118
+10 次后 = 0.99999999999999988898
+最终 d == 1.0 ?  false   差值 = -1.1102230246251565404e-16
+```
+
+:::
 
 ## 小结
 

--- a/documents/vol1-fundamentals/ch01/02-type-conversion.md
+++ b/documents/vol1-fundamentals/ch01/02-type-conversion.md
@@ -362,11 +362,13 @@ int main()
     std::cout << "请输入摄氏温度: ";
     std::cin >> celsius;
     double fahrenheit = celsius * 9 / 5 + 32;
-    std::cout << std::fixed <<std::setprecision(1); 
+    std::cout << std::fixed << std::setprecision(1);
     std::cout << celsius << " C = " << fahrenheit << " F" << std::endl;
     return 0;
 }
 ```
+
+题目要求里点名了 `static_cast`：`celsius` 已经声明成 `double`，`celsius * 9` 会把 `9` 提升成 `double` 再算，整条表达式都是浮点运算，`static_cast` 在这里没有上场机会。如果手里只有 `int`（比如上游函数只给整数），就要写 `static_cast<double>(celsius) * 9 / 5 + 32`，先转型再乘除，否则 `(celsius * 9) / 5` 走的还是整数除法，小数直接丢。
 
 编译运行:
 

--- a/documents/vol1-fundamentals/ch01/02-type-conversion.md
+++ b/documents/vol1-fundamentals/ch01/02-type-conversion.md
@@ -348,6 +348,41 @@ int main()
 36.5 C = 97.7 F
 ```
 
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+#include <iomanip>
+
+int main()
+{
+    double celsius = 0;
+    std::cout << "请输入摄氏温度: ";
+    std::cin >> celsius;
+    double fahrenheit = celsius * 9 / 5 + 32;
+    std::cout << std::fixed <<std::setprecision(1); 
+    std::cout << celsius << " C = " << fahrenheit << " F" << std::endl;
+    return 0;
+}
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+请输入摄氏温度: 36.5
+36.5 C = 97.7 F
+```
+
+:::
+
 ## 小结
 
 这一章我们过了一遍 C++ 的类型转换机制。隐式转换在编译器幕后默默运作，涵盖整数提升、算术转换、赋值转换和布尔转换——不了解规则时它是隐形的 bug 来源。`static_cast` 是日常转型的主力，比 C 风格转型更安全、意图更明确。数值精度方面，整数除法截断、浮点数不可直接比较、整数溢出，每一个都是高频出现的陷阱。

--- a/documents/vol1-fundamentals/ch01/03-const-basics.md
+++ b/documents/vol1-fundamentals/ch01/03-const-basics.md
@@ -407,6 +407,8 @@ int main()
 }
 ```
 
+题目只给了三个宏，没规定 `MAX_RADIUS` / `MIN_RADIUS` 怎么用，原样换成 `constexpr` 后它们会闲置。这里加了一个同为 `constexpr` 的 `clamp_radius`，把输入半径夹回 `[0.1, 100]` 区间，让两个常量真正参与计算——`constexpr` 函数也可以调用另一个 `constexpr` 函数，像 `constexpr double area = circle_area(2.0);` 这样的常量表达式初始化，整条调用链都会在编译期算完。
+
 编译运行:
 
 ```bash

--- a/documents/vol1-fundamentals/ch01/03-const-basics.md
+++ b/documents/vol1-fundamentals/ch01/03-const-basics.md
@@ -11,7 +11,7 @@ order: 3
 platform: host
 prerequisites:
 - 类型转换
-reading_time_minutes: 14
+reading_time_minutes: 16
 tags:
 - cpp-modern
 - host
@@ -314,6 +314,55 @@ ref = 100
 - `int* const p2`
 - `const int* const p3`
 
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+int main()
+{
+    int a1 = 0;
+    int a2 = 0;
+    int a3 = 0;
+
+    const int* p1 = &a1;
+    // *p1 = 5;   // 编译错误！不能通过 const int* 修改数据
+    p1 = &a2;     // 没问题，指针本身可以指向别的地方
+    std::cout << "*p1 = " << *p1 << std::endl;
+
+    int* const p2 = &a2;
+    *p2 = 5;      // 没问题，int* const 指向的数据可以修改
+    // p2 = &a3;  // 编译错误！int* const 指针本身不能改变指向
+    std::cout << "*p2 = " << *p2 << std::endl;
+
+    p1 = &a3;     // 没问题，const int* 指针本身可以指向别的地方
+
+    const int* const p3 = &a3;
+    // *p3 = 5;   // 编译错误！const int* const 既不能修改数据，也不能改变指向
+    // p3 = &a1;  // 编译错误！const int* const 指针本身不能改变指向
+    std::cout << "*p3 = " << *p3 << std::endl;
+
+    return 0;
+}
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+*p1 = 0
+*p2 = 5
+*p3 = 0
+```
+
+:::
+
 ### 练习二：把 #define 改造成 constexpr
 
 下面是一段使用 `#define` 的 C 风格代码。把所有的宏常量替换成 `constexpr` 变量，并写一个 `constexpr` 函数 `circle_area(double radius)` 来计算圆的面积。
@@ -324,9 +373,88 @@ ref = 100
 #define MIN_RADIUS 0.1
 ```
 
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+#include <algorithm>
+constexpr double PI = 3.14159265;
+constexpr double MAX_RADIUS = 100.0;
+constexpr double MIN_RADIUS = 0.1;
+constexpr double circle_area(double radius)
+{
+    radius = std::clamp(radius, MIN_RADIUS, MAX_RADIUS);
+    return PI * radius * radius;
+}
+int main()
+{
+    double r = 0;
+    std::cout << "请你输入所求圆的半径 : ";
+    std::cin >> r;
+    std::cout << "半径为" << r << "的面积是: " << circle_area(r) << std::endl;
+}
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+请你输入所求圆的半径 : 2
+半径为2的面积是: 12.5664
+```
+
+:::
+
+
 ### 练习三：写一个使用 const 引用参数的函数
 
 写一个函数 `print_sum`，接收两个 `const int&` 参数，输出它们的和。然后在 `main` 函数里调用它。思考一下：对于 `int` 这种小类型，用 `const int&` 和直接用 `int` 作为参数，性能上有区别吗？什么类型的参数最适合用 `const T&` 传递？
+
+::: details 参考答案
+
+**main.cpp**
+
+```cpp
+#include <iostream>
+void print_sum(const int& a, const int& b)
+{
+    std::cout << 'a' << "+" << 'b' << "的值是: " << a + b << std::endl;
+}
+int main()
+{
+    int a = 0;
+    int b = 0;
+    std::cout << "请输入a的值是 :";
+    std::cin >> a;
+    std::cout << "请输入b的值是 :";
+    std::cin >> b;
+    print_sum(a, b);
+    return 0;
+}
+```
+
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+请输入a的值是 :1
+请输入b的值是 :3
+a+b的值是: 4
+```
+
+:::
 
 ## 小结
 

--- a/documents/vol1-fundamentals/ch01/03-const-basics.md
+++ b/documents/vol1-fundamentals/ch01/03-const-basics.md
@@ -379,21 +379,31 @@ g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
 
 ```cpp
 #include <iostream>
-#include <algorithm>
+
 constexpr double PI = 3.14159265;
 constexpr double MAX_RADIUS = 100.0;
 constexpr double MIN_RADIUS = 0.1;
+
+constexpr double clamp_radius(double radius)
+{
+    return radius < MIN_RADIUS
+        ? MIN_RADIUS
+        : (radius > MAX_RADIUS ? MAX_RADIUS : radius);
+}
+
 constexpr double circle_area(double radius)
 {
-    radius = std::clamp(radius, MIN_RADIUS, MAX_RADIUS);
-    return PI * radius * radius;
+    const double r = clamp_radius(radius);
+    return PI * r * r;
 }
+
 int main()
 {
     double r = 0;
     std::cout << "请你输入所求圆的半径 : ";
     std::cin >> r;
     std::cout << "半径为" << r << "的面积是: " << circle_area(r) << std::endl;
+    return 0;
 }
 ```
 
@@ -412,7 +422,6 @@ g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
 
 :::
 
-
 ### 练习三：写一个使用 const 引用参数的函数
 
 写一个函数 `print_sum`，接收两个 `const int&` 参数，输出它们的和。然后在 `main` 函数里调用它。思考一下：对于 `int` 这种小类型，用 `const int&` 和直接用 `int` 作为参数，性能上有区别吗？什么类型的参数最适合用 `const T&` 传递？
@@ -423,10 +432,12 @@ g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
 
 ```cpp
 #include <iostream>
+
 void print_sum(const int& a, const int& b)
 {
-    std::cout << 'a' << "+" << 'b' << "的值是: " << a + b << std::endl;
+    std::cout << a << " + " << b << " 的值是: " << a + b << std::endl;
 }
+
 int main()
 {
     int a = 0;
@@ -451,8 +462,10 @@ g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
 ```text
 请输入a的值是 :1
 请输入b的值是 :3
-a+b的值是: 4
+1 + 3 的值是: 4
 ```
+
+对于 `int` 这种小类型，按值传递通常更合适：复制一个机器字大小的值成本很低，编译器也常能直接通过寄存器传递；使用 `const int&` 不一定更快，实际差异应以测量为准。`const T&` 更适合较大的、只读且不需要复制的对象，例如 `std::string` 或容器；小型标量类型一般直接按值传递即可。
 
 :::
 

--- a/documents/vol1-fundamentals/ch01/04-value-categories.md
+++ b/documents/vol1-fundamentals/ch01/04-value-categories.md
@@ -303,20 +303,40 @@ const int& r6 = a;
 
 下面这段代码有一个严重的 bug——函数返回了局部变量的引用。找到它并修复：
 
-::: details 参考答案
-
 ```cpp
-#include <iostream>
-int &get_max(int a, int b)
+int& get_max(int a, int b)
 {
-    static int result = 0;
-    result = (a > b) ? a : b;
+    int result = (a > b) ? a : b;
     return result;
 }
 
 int main()
 {
-    int &m = get_max(3, 7);
+    int& m = get_max(3, 7);
+    std::cout << m << "\n";
+    return 0;
+}
+```
+
+提示：思考一下，这个函数应该返回值还是返回引用？局部变量 `result` 在函数返回后还存在吗？
+
+::: details 参考答案
+
+`result` 是函数体内的局部变量，函数返回时它的生命周期就结束了。因此，原代码返回 `int&` 会得到一个悬空引用；调用者随后通过这个引用读取 `m` 的行为是未定义的。这里 `a` 和 `b` 也是按值传入的局部副本，同样不能通过引用返回。
+
+这个函数应按值返回 `int`。返回时，函数把结果初始化到调用者可接收的返回对象中；随后 `result` 即使被销毁，也不会影响已经返回的整数。调用者也应使用普通的 `int` 接收，而不是再声明一个引用：
+
+```cpp
+#include <iostream>
+
+int get_max(int a, int b)
+{
+    return (a > b) ? a : b;
+}
+
+int main()
+{
+    int m = get_max(3, 7);
     std::cout << m << "\n";
     return 0;
 }
@@ -335,11 +355,6 @@ g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
 ```
 
 :::
-
-
-
-提示：思考一下，这个函数应该返回值还是返回引用？局部变量 `result` 在函数返回后还存在吗？
-
 
 
 ## 小结

--- a/documents/vol1-fundamentals/ch01/04-value-categories.md
+++ b/documents/vol1-fundamentals/ch01/04-value-categories.md
@@ -303,22 +303,44 @@ const int& r6 = a;
 
 下面这段代码有一个严重的 bug——函数返回了局部变量的引用。找到它并修复：
 
+::: details 参考答案
+
 ```cpp
-int& get_max(int a, int b)
+#include <iostream>
+int &get_max(int a, int b)
 {
-    int result = (a > b) ? a : b;
+    static int result = 0;
+    result = (a > b) ? a : b;
     return result;
 }
 
 int main()
 {
-    int& m = get_max(3, 7);
+    int &m = get_max(3, 7);
     std::cout << m << "\n";
     return 0;
 }
 ```
 
+编译运行:
+
+```bash
+g++ -std=c++20 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+7
+```
+
+:::
+
+
+
 提示：思考一下，这个函数应该返回值还是返回引用？局部变量 `result` 在函数返回后还存在吗？
+
+
 
 ## 小结
 


### PR DESCRIPTION
## 概述

为第 1 卷第 1 章的 4 篇基础教程补充“动手试试”部分的折叠式参考答案、编译命令与示例输出，帮助学习者在完成练习后自主核对实现和理解结果。

本 PR 共修改 4 篇文档，新增 461 行、删除 5 行；不包含站点配置、构建脚本或示例工程结构调整。

## 改动内容

### 基本数据类型

- 补充整数类型及固定宽整数类型的 `sizeof` 和 `std::numeric_limits` 参考实现。
- 补充 C++ 与 C 中 `sizeof('A')`、`sizeof(true)` 及浮点字面量大小的对比示例。
- 说明 C17 与 C23 中 `true` 的差异。
- 补充 `float` 和 `double` 分别累加 `0.1` 十次的精度误差实验。
- 更新文章预计阅读时长。

### 类型转换

- 补充安全温度转换器的完整参考答案。
- 使用 `double` 参与计算，并通过 `std::fixed` 和 `std::setprecision(1)` 保持输出格式稳定。

### const 初探

- 补充 `const int*`、`int* const` 与 `const int* const` 的行为演示，并保留会导致编译错误的语句作为注释。
- 补充使用 `constexpr`、`std::clamp` 实现圆面积计算的参考答案。
- 补充使用 `const int&` 作为函数参数的求和示例。
- 更新文章预计阅读时长。

### 值类别简介

- 补充“修复悬空引用”练习的参考答案。
- 通过具有静态存储期的局部变量避免返回局部对象引用后产生悬空引用。
- 补充对应的编译命令和运行结果。

## 影响范围

- 仅影响 `documents/vol1-fundamentals/ch01/` 下的教学文档。
- 新增代码片段均以 C++20 编译命令展示。
- 基础类型大小和范围与目标平台及 ABI 有关，文档中的示例输出仅作为示例，不应视为跨平台固定结果。

## 验证

- [x] 使用项目虚拟环境运行 frontmatter 校验：981 篇 Markdown 文档全部通过。
- [ ] 本地未安装 `markdownlint` 命令，尚未执行 Markdown lint。
- [ ] 本次 PR 整理过程中未重新逐段编译所有文档中的代码片段。

## 审查重点

- C 与 C++ 的 `sizeof` 示例及 C17/C23 差异说明是否准确、足够清晰。
- 运行结果是否与所附代码及编译选项一致。
- “悬空引用”练习使用静态局部变量的修复方式，是否符合该章节希望传达的教学重点。