### PR TITLE
fix: 005 oop vars ref error, which migrated at early stage

### DIFF
--- a/documents/en/vol1-fundamentals/ch08/05-oop-in-practice.md
+++ b/documents/en/vol1-fundamentals/ch08/05-oop-in-practice.md
@@ -295,7 +295,7 @@ Then there are several utility methods:
     {
         double sum = 0;
         for (const auto& shape : shapes_) {
-            sum += shape_->area();
+            sum += shape->area();
         }
         return sum;
     }

--- a/documents/vol1-fundamentals/ch08/05-oop-in-practice.md
+++ b/documents/vol1-fundamentals/ch08/05-oop-in-practice.md
@@ -287,7 +287,7 @@ public:
     {
         double sum = 0;
         for (const auto& shape : shapes_) {
-            sum += shape_->area();
+            sum += shape->area();
         }
         return sum;
     }


### PR DESCRIPTION
感谢 @ypj0 大佬的勘误！这里光速审查 + 勘误了！早期迁移的时候写的石山没验证就迁移了，我说老资产要审查了qaq
