### PR TITLE
ci: 站点构建检查增加 Windows 线

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -44,9 +44,11 @@ jobs:
         with:
           path: site/.vitepress/.build-cache
           key: vitepress-build-${{ runner.os }}-${{ hashFiles('documents/**', 'site/.vitepress/config/**', 'site/.vitepress/plugins/**', 'site/.vitepress/public/**', 'site/.vitepress/theme/**', 'scripts/build.ts', 'package.json', 'pnpm-lock.yaml') }}
+          # 兜底必须限定 runner.os:manifest 是纯内容哈希(跨 OS 恒等),
+          # 若不限定,Windows 腿会恢复 Linux 条目并整卷判为 cached,跳过
+          # 全部分卷构建——Windows 专属代码路径(junction/重试)就测不到了。
           restore-keys: |
             vitepress-build-${{ runner.os }}-
-            vitepress-build-
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # 双 OS 矩阵:scripts/build.ts 的 Windows 分卷逻辑(链接 junction / 目录重试)
+    # 需要一条 CI 线守住回归,否则只能靠本地手工验证。deploy 仍固定 ubuntu(产物与构建 OS 无关)。
+    strategy:
+      fail-fast: false   # 一条腿挂了也让另一条跑完,PR 上能同时看到两个 OS 的结果
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   build:
-    # 双 OS 矩阵:scripts/build.ts 的 Windows 分卷逻辑(链接 junction / 目录重试)
-    # 需要一条 CI 线守住回归,否则只能靠本地手工验证。deploy 仍固定 ubuntu(产物与构建 OS 无关)。
     strategy:
       fail-fast: false   # 一条腿挂了也让另一条跑完,PR 上能同时看到两个 OS 的结果
       matrix:


### PR DESCRIPTION
build-check.yml 改为 ubuntu/windows 双 OS 矩阵,守住 scripts/build.ts 中 Windows 分卷构建逻辑(junction 链接、目录重试)的回归。deploy 仍固定
ubuntu——部署产物与构建 OS 无关。缓存键已含 runner.os,天然双 OS 隔离。

Refs #181