### PR TITLE
docs(cpp): 补全引用基础练习答案

### DIFF
--- a/documents/vol1-fundamentals/ch04/03-references.md
+++ b/documents/vol1-fundamentals/ch04/03-references.md
@@ -338,6 +338,53 @@ void double_values(int* arr, int n)
 
 提示：C 风格数组没法直接用引用传参来保留长度信息，可以考虑用 `std::array<int, N>` 替代。
 
+::: details 参考答案
+
+```cpp
+#include <iostream>
+#include <array>
+
+void double_values(std::array<int, 5>& arr)
+{
+    for (auto& value : arr) {
+        value *= 2;
+    }
+}
+
+int main()
+{
+    std::array<int, 5> values{1, 2, 3, 4, 5};
+
+    std::cout << "修改前: ";
+    for (const auto& value : values) {
+        std::cout << value << " ";
+    }
+    std::cout << std::endl;
+    double_values(values);
+    std::cout << "修改后: ";
+    for (const auto& value : values) {
+        std::cout << value << " ";
+    }
+    std::cout << std::endl;
+    return 0;
+}
+```
+
+编译运行:
+
+```bash
+g++ -std=c++17 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果:
+
+```text
+修改前: 1 2 3 4 5 
+修改后: 2 4 6 8 10 
+```
+
+:::
+
 ### 练习二：找错
 
 下面这段代码有几处与引用相关的问题，把它们全部找出来：
@@ -353,17 +400,72 @@ void process(int& ref) { ref += 10; }
 
 int main()
 {
-    int& r = get_value();
-    int& uninit;              // 行 A
+    int& r = get_value(); // 行 A
+    int& uninit;          // 行 B
     int a = 10;
     int& ref = a;
     int b = 20;
-    ref = &b;                 // 行 B
-    process(5);               // 行 C
+    ref = &b;             // 行 C
+    process(5);           // 行 D
 }
 ```
 
 逐行分析：哪几行有编译错误？哪几行是运行时的未定义行为？
+
+::: details 参考答案
+
+先给结论：**行 B、行 C、行 D 是编译错误；按题目的二分法，运行时隐患记为行 A。** 更精确地说，`get_value()` 的返回语句和行 A 可以编译，但会留下悬空引用；对 `r` 的读写才会触发运行时未定义行为。
+
+| 位置 | 结果 | 原因 |
+| --- | --- | --- |
+| `return x;` | 可编译，编译器通常会警告 | `x` 是自动存储期的局部变量，函数返回时它的生命周期结束；返回的 `int&` 不会把 `x` 的生命周期延长。 |
+| 行 A：`int &r = get_value();` | 可编译，但 `r` 是悬空引用 | `r` 绑定到已经结束生命周期的 `x`。这一步本身只是制造了悬空引用；后续通过 `r` 读取或写入（例如 `std::cout << r`）才是未定义行为。 |
+| 行 B：`int &uninit;` | **编译错误** | 引用声明必须在声明时初始化，不能像指针那样先声明、之后再绑定。 |
+| `int a = 10;`、`int &ref = a;`、`int b = 20;` | 正确 | `ref` 在声明时绑定到了仍然存活的 `a`。 |
+| 行 C：`ref = &b;` | **编译错误** | `ref` 表达式的类型是 `int`，而 `&b` 的类型是 `int*`；并且赋值不会让引用改绑到另一个对象。给 `a` 赋 `b` 的值应写 `ref = b`，若要改指向则必须重新声明引用或改用指针。 |
+| 行 D：`process(5);` | **编译错误** | `process` 要求可修改的 `int&`，而字面量 `5` 是右值，不能绑定到非 `const` 左值引用。应传入一个具名的 `int` 左值。 |
+
+这里最容易混淆的是行 A：严格地说，**悬空引用是错误状态，访问悬空引用才是运行时未定义行为**。例如把 B、C、D 暂时注释掉后，下面的读取就会触发 UB：
+
+```cpp
+int &r = get_value();
+std::cout << r;  // 未定义行为：r 指向的 x 已经结束生命周期
+```
+
+一种安全的修正版是让 `get_value` 按值返回，并在声明时为引用提供初始对象；如果确实要返回引用，则只能返回生命周期足够长的对象（例如静态对象或调用者传入的对象）：
+
+```cpp
+int get_value()
+{
+    return 42;
+}
+
+void process(int& ref) { ref += 10; }
+
+int main()
+{
+    int r = get_value();
+
+    int data = 0;
+    int& uninit = data;
+
+    int a = 10;
+    int& ref = a;
+    int b = 20;
+    ref = b;
+
+    int value = 5;
+    process(value);
+
+    (void)r;
+    (void)uninit;
+}
+```
+
+
+
+:::
+
 
 ### 练习三：实现一个简单的链式配置器
 
@@ -373,6 +475,37 @@ int main()
 Config c;
 c.set_width(800).set_height(600);
 ```
+
+::: details 参考答案
+
+```cpp
+#include <iostream>
+
+class Config {
+    int width_{};
+    int height_{};
+
+public:
+    Config& set_width(int width)
+    {
+        width_ = width;
+        return *this;
+    }
+    Config& set_height(int height)
+    {
+        height_ = height;
+        return *this;
+    }
+};
+int main()
+{
+    Config c;
+    c.set_width(800).set_height(600);
+    return 0;
+}
+```
+
+:::
 
 ## 小结
 


### PR DESCRIPTION
## 概述

本 PR 为第一卷第 4 章《03-references:引用》的三道练习题补全参考答案,是练习答案补全系列(##201、##203、##206、##207)的延续。答案统一放在 VitePress `::: details` 折叠块内,默认收起,不干扰正文阅读;读者做完题后可展开对照。

## 主要变更

### ✅ 完成内容

- **练习一:用引用修改数组**
  - 按题目提示采用 `std::array<int, 5>&` 传参,替代无法保留长度信息的 C 风格数组
  - 答案内含完整可编译程序、编译命令(`g++ -std=c++17 -Wall -Wextra`)与实测运行结果

- **练习二:找错(悬空引用辨析)**
  - 用表格逐行给出"编译错误 vs 运行时未定义行为"的结论与原因
  - 重点澄清了本题最易混淆的点:**制造悬空引用(行 A `int& r = get_value();`)本身可以编译,通过它读写才是 UB**——与题目"二分法"表述的差异单独用一段说明
  - 给出三种错误的修正方向:按值返回 `get_value`、声明时必须初始化引用、传入具名左值代替字面量
  - 附完整修正版代码

- **练习三:链式配置器**
  - `Config` 类两个 setter 均返回 `Config&`,成员用 `int width_{} / int height_{}` 就地初始化
  - 演示 `c.set_width(800).set_height(600);` 链式调用

### 📝 技术亮点

- 练习二没有停留在"哪个行报错",而是区分了 **错误状态**(悬空引用,可编译)与 **触发 UB 的动作**(访问悬空引用)两个阶段,并给出最小复现代码片段(`std::cout << r;`)
- 所有断言均经本地编译实测(GCC 诊断与文中结论逐字吻合),修正版以 `-Wall -Wextra` 零警告通过

### 📄 变更文件

- [documents/vol1-fundamentals/ch04/03-references.md](https://github.com/Awesome-Embedded-Learning-Studio/Tutorial_AwesomeModernCPP/blob/ch04-3/documents/vol1-fundamentals/ch04/03-references.md)(+137 / −4)

  其中 −4 行为练习二题干代码的行号标注修正:原 A/B/C 三处注释顺延为 A/B/C/D,与新增解析一一对应。

## 测试

本机环境:Windows 10 x64 + MinGW-w64 GCC 8.1.0

- [x] 练习一答案通过 `g++ -std=c++17 -Wall -Wextra ex1.cpp -o ex1 && ./ex1` 编译运行,输出与文中一致(零警告)
- [x] 练习二原错误代码逐行验证:行 B/C/D 均产生编译错误(错误信息见上),行 A 仅触发 `[-Wreturn-local-addr]` / `[-Wunused-variable]` 警告,与解析结论一致
- [x] 练习二修正版通过同一命令编译运行,`-Wall -Wextra` 零警告
- [x] 练习三答案编译运行通过,链式调用正常
- [x] `markdownlint documents/vol1-fundamentals/ch04/03-references.md` 通过
- [x] `.venv` Python 运行 `scripts/validate_frontmatter.py`:991 个文件全部通过,0 错误
- [x] 3 对 `::: details ... :::` 折叠块配对正确,VitePress 渲染无异常

## 后续计划

ch04 尚有两篇文章的练习未补答案,计划后续 PR 继续:

- [ ] `02-pointer-arithmetic.md`(3 道练习)
- [ ] `04-smart-ptr-preview.md`(2 道练习)

## 相关 Issue

无(练习答案补全系列任务)