### PR TITLE
docs(cpp): 补全智能指针预告练习参考答案

### DIFF
--- a/documents/vol1-fundamentals/ch04/04-smart-ptr-preview.md
+++ b/documents/vol1-fundamentals/ch04/04-smart-ptr-preview.md
@@ -11,7 +11,7 @@ order: 4
 platform: host
 prerequisites:
 - 引用
-reading_time_minutes: 9
+reading_time_minutes: 10
 tags:
 - cpp-modern
 - host
@@ -269,6 +269,34 @@ void use_sensor(bool early_exit)
 }
 ```
 
+::: details 参考答案
+
+```cpp
+#include <iostream>
+#include <memory>
+
+struct Sensor
+{
+    int id;
+    Sensor(int i) : id(i) { std::cout << "Sensor " << id << " 初始化\n"; }
+    ~Sensor() { std::cout << "Sensor " << id << " 关闭\n"; }
+    void read() { std::cout << "Sensor " << id << " 读取数据\n"; }
+};
+
+void use_sensor(bool early_exit)
+{
+    auto s = std::make_unique<Sensor>(1);
+    s->read();
+    if (early_exit)
+    {
+        return;
+    }
+    s->read();
+}
+```
+
+:::
+
 ### 练习二：识别内存泄漏模式
 
 下面这段代码有两个泄漏点（`choice == 1` 和 `choice == 2` 两个分支各一个），想想用 `unique_ptr` 包装 `a` 和 `b` 之后，提前 return 和 throw 还是问题吗？
@@ -284,6 +312,33 @@ void process(int choice)
     delete b;
 }
 ```
+
+::: details 参考答案
+
+原代码有两个泄漏点：
+
+- 当 `choice == 1` 时，函数直接 `return`，`a` 和 `b` 都还没有执行 `delete`。
+- 当 `choice == 2` 时，`a` 已经释放，但抛出异常会跳过 `delete b`，因此 `b` 泄漏。
+
+用 `unique_ptr` 接管所有权后，提前 `return` 和 `throw` 都不再是问题。函数离开作用域时，局部的 `unique_ptr` 会自动析构并释放它所管理的内存；无论是正常返回，还是异常导致的栈展开，析构函数都会被调用。因此不需要再手动写 `delete`：
+
+```cpp
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+void process(int choice)
+{
+    auto a = std::make_unique<int>(10);
+    auto b = std::make_unique<int>(20);
+    if (choice == 1) { return; }
+    if (choice == 2) { throw std::runtime_error("error"); }
+}
+```
+
+这里 `a` 和 `b` 都由 `unique_ptr` 独占管理。函数退出时，先析构后创建的 `b`，再析构 `a`，两块内存都会被正确释放。
+
+:::
 
 ---
 


### PR DESCRIPTION
## 概述

本 PR 为第 4 章末篇《智能指针预告》的两道课后练习补全了参考答案，帮助学习者在做完题后对照验证，加深对 `unique_ptr` 自动内存管理(RAII)的理解。

## 主要变更

### ✅ 完成内容

**练习一：改造裸指针程序**

- 提供 `unique_ptr` + `make_unique` 的完整改造版本，替换原题中的裸指针 + 手动 `delete` 写法
- 通过 `Sensor` 构造/析构函数中的打印，直观展示提前 `return` 时析构函数依然会被调用，内存自动释放
- 使用 VitePress `::: details` 折叠块，答案默认折叠，不干扰先做题的读者

**练习二：识别内存泄漏模式**

- 逐一分析原代码的两个泄漏点：
  - `choice == 1`：提前 `return`,`a`、`b` 均未 `delete`,双双泄漏
  - `choice == 2`:`a` 已释放，但抛出异常跳过 `delete b`,`b` 泄漏
- 给出 `unique_ptr` 改造版本，说明无论是正常返回还是异常栈展开，局部 `unique_ptr` 的析构函数都会执行
- 补充析构顺序说明：函数退出时按构造的逆序析构，先析构 `b` 再析构 `a`

### 📄 其他调整

- `reading_time_minutes`: 9 → 10(新增答案内容增加了阅读时长)

## 变更文件

- `documents/vol1-fundamentals/ch04/04-smart-ptr-preview.md`(+56 / −1)

## 测试与验证方式

本机环境：Windows 10 + WSL2(Ubuntu 24.04),g++ 13.3.0

- [x] 两段答案代码均通过 `g++ -std=c++17 -Wall -Wextra` 编译，无任何警告
- [x] 练习一运行验证:`early_exit = true/false` 两条路径下 `Sensor` 均正确构造、析构，提前返回路径同样触发析构输出
- [x] 练习二以 `-fsanitize=address,leak` 编译并运行验证:`choice = 1/2/3` 三条路径退出后均无泄漏报告，异常路径栈展开行为符合预期
- [x] 运行 `python scripts/validate_frontmatter.py`:991 个文件全部通过，0 error
- [x] markdownlint(使用仓库 `.markdownlint.json` 配置)通过
- [x] 纯文档变更，基于已有文章修改，无需更新导航或索引

练习一实际运行输出(节选)：

```text
--- early_exit = true ---
Sensor 1 初始化
Sensor 1 读取数据
Sensor 1 关闭          ← 提前 return,析构依然执行
--- early_exit = false ---
Sensor 1 初始化
Sensor 1 读取数据
Sensor 1 读取数据
Sensor 1 关闭
```

## 相关 Issue

无。