### PR TITLE
docs(cpp): 补全 C 风格数组练习参考答案

### DIFF
--- a/documents/vol1-fundamentals/ch05/01-c-arrays.md
+++ b/documents/vol1-fundamentals/ch05/01-c-arrays.md
@@ -11,7 +11,7 @@ order: 1
 platform: host
 prerequisites:
 - 智能指针预告
-reading_time_minutes: 10
+reading_time_minutes: 13
 tags:
 - cpp-modern
 - host
@@ -369,9 +369,127 @@ int main()
 
 写一个程序，声明一个包含 10 个整数的数组，写两个函数分别计算总和和平均值（平均值返回 `double`）。验证方法：手动加一遍，和程序输出对比。
 
+::: details 参考答案
+
+```cpp
+#include <iostream>
+
+constexpr int sum(const int a[], int n)
+{
+    int total = 0;
+
+    for (int i = 0; i < n; i++)
+    {
+        total += a[i];
+    }
+
+    return total;
+}
+
+constexpr double average(const int a[], int n)
+{
+    if (n == 0 || n < 0)
+        return 0.0;
+
+    return static_cast<double>(sum(a, n)) / n;
+}
+
+int main()
+{
+    constexpr int arr[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    constexpr int size = sizeof(arr) / sizeof(arr[0]);
+
+    constexpr int total = sum(arr, size);
+    constexpr double avg = average(arr, size);
+
+    std::cout << "总和: " << total << std::endl;
+    std::cout << "平均值: " << avg << std::endl;
+
+    return 0;
+}
+```
+
+编译运行：
+
+```bash
+g++ -std=c++17 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果：
+
+```text
+总和: 55
+平均值: 5.5
+```
+
+:::
+
 ### 练习二：矩阵转置
 
-写一个函数，将 N x M 的二维数组转置为 M x N。先用固定大小（2x3 转置为 3x2）实现，再思考：如果行数列数也要是参数，C 风格数组能做到吗？
+写一个函数，将 N × M 的二维数组转置为 M × N。先用固定大小（2×3 转置为 3×2）实现，再思考：如果行数、列数要在运行时传入，标准 C++ 应该如何表示这块矩阵内存？
+
+::: details 参考答案
+
+**2x3 转置为 3x2**
+
+```cpp
+constexpr void transpose_2x3(const int (&matrix)[2][3], int (&result)[3][2])
+{
+    for (int i = 0; i < 2; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            result[j][i] = matrix[i][j];
+        }
+    }
+}
+```
+
+**C99 中的 VLA 写法（不是标准 C++）**
+
+```c
+void transpose(int m, int n, const int matrix[m][n], int result[n][m])
+{
+    for (int i = 0; i < m; i++)
+    {
+        for (int j = 0; j < n; j++)
+        {
+            result[j][i] = matrix[i][j];
+        }
+    }
+}
+```
+
+上面的函数参数使用了**变长数组**（variable-length array，VLA）语法：`matrix[m][n]` 和
+`result[n][m]` 的边界由运行时参数决定。这是 C99 支持的特性（C11 将 VLA 列为可选特性），
+但它不是标准 C++ 的语法；即使某些 C++ 编译器接受，也属于编译器扩展，不能写进可移植的
+C++ 代码。
+
+**标准 C++ 的运行时尺寸写法**
+
+标准 C++ 中，内置数组的边界属于类型的一部分，不能用普通函数参数表达运行时尺寸。因此，
+"行数和列数都是参数"并不意味着 C 风格数组完全不能参与函数调用，而是不能直接写成
+`int matrix[m][n]` 这种 VLA 形式。一个简单且可移植的办法是把矩阵按行连续存储为一维数组，
+再额外传入行数和列数：
+
+```cpp
+void transpose(int rows, int cols, const int* matrix, int* result)
+{
+    for (int row = 0; row < rows; ++row)
+    {
+        for (int col = 0; col < cols; ++col)
+        {
+            result[col * rows + row] = matrix[row * cols + col];
+        }
+    }
+}
+```
+
+调用者需要保证 `matrix` 至少包含 `rows * cols` 个元素，`result` 至少包含同样多的元素。
+如果希望保留二维下标形式，可以使用模板表示编译期固定的行列数，或使用 `std::vector`、
+`std::span` 等更适合表达运行时尺寸的类型。
+
+:::
 
 ### 练习三：修复越界 bug
 
@@ -383,6 +501,17 @@ for (int i = 0; i <= 5; ++i) {  // 提示：仔细看循环条件
     std::cout << data[i] << std::endl;
 }
 ```
+
+::: details 参考答案
+
+```cpp
+int data[5] = {10, 20, 30, 40, 50};
+for (int i = 0; i < 5; ++i) {
+    std::cout << data[i] << std::endl;
+}
+```
+
+:::
 
 这种 off-by-one 错误在初学者代码里非常常见。
 


### PR DESCRIPTION
## 投稿类型

- [ ] 社区来稿初刊：希望先进入 `documents/community/incoming/`
- [x] 现有文章改进
- [ ] 翻译或双语同步
- [ ] 其他

## 文章说明

### 概述

本 PR 为第一卷第 5 章第 1 篇《C 风格数组》（`documents/vol1-fundamentals/ch05/01-c-arrays.md`）的「动手试试」小节补全三道练习的参考答案，延续 #201、#206、#207 的练习答案补全系列，格式与既有答案保持一致：使用 VitePress `::: details 参考答案` 折叠块，正文题面保持不变，读者可先自行作答再展开对照。

### ✅ 完成内容

**练习一：数组求和与均值**
- 给出完整可编译程序：`constexpr int sum(const int a[], int n)` 与 `constexpr double average(const int a[], int n)` 两个函数，返回类型按题面要求区分 `int` / `double`。
- `average` 对 `n == 0 || n < 0` 做了防御性处理：避免常量求值中出现除以零（否则 `constexpr` 调用直接编译失败），也避免负数长度被误用。
- 主函数用 `constexpr` 变量接收结果，演示了这套写法可以在编译期完成计算；附编译命令与运行结果（总和 `55`、平均值 `5.5`），读者可按题面要求手动验算对照。

**练习二：矩阵转置**（本题是本次的重点，题面原本只留了思考题，答案分三层展开）
1. **固定尺寸版本**：`constexpr void transpose_2x3(const int (&matrix)[2][3], int (&result)[3][2])`，用数组引用作形参把维度纳入类型系统，行数列数不匹配会在编译期报错。
2. **C99 VLA 写法（明确标注"不是标准 C++"）**：先展示 `void transpose(int m, int n, const int matrix[m][n], int result[n][m])` 这种变长数组形参，再用一段文字讲清它的标准归属——C99 引入、C11 起降级为可选特性、不被任何 C++ 标准接受，编译器接受也属于扩展，不能写进可移植的 C++ 代码。这直接回答了题面"如果行数列数也要是参数，C 风格数组能做到吗"的思考题。
3. **标准 C++ 的可移植写法**：内置数组的边界是类型的一部分，无法用普通函数参数表达运行时尺寸，因此给出"按行展开成一维数组 + 额外传行列数"的版本，并写明调用者契约（两个缓冲区都至少要有 `rows * cols` 个元素）和改进方向（模板表达编译期维度，或改用 `std::vector` / `std::span` 表达运行时尺寸）。

此外将本题题面从"如果行数列数也要是参数，C 风格数组能做到吗？"微调为"如果行数、列数要在运行时传入，标准 C++ 应该如何表示这块矩阵内存？"，把问题从"能不能"引导到"标准 C++ 里该怎么做"，与答案的展开方式呼应；同时统一了乘号的排版（`N x M` → `N × M`）。

**练习三：修复越界 bug**
- 给出修复后的代码：循环条件 `i <= 5` 改为 `i < 5`，消除对 `data[5]` 的越界读（未定义行为），并与正文"最大合法下标是 N−1"的结论呼应。

**Frontmatter**
- `reading_time_minutes: 10` → `13`，反映新增的三段参考答案带来的阅读量变化。

### 📝 技术亮点

- 全部答案函数使用 `constexpr`，体现 C 风格数组 + 编译期计算的组合。
- 数组引用形参（`const int (&)[2][3]`）保留完整类型信息，规避了"数组退化为指针、丢失维度"的经典坑，与正文知识点形成闭环。
- 对 VLA 的讲解不止给结论，还给出标准版本脉络（C99 → C11 可选 → 不属于 C++），并区分"编译器扩展"与"可移植代码"的边界。
- 一维展开 + 行列数参数的写法示范了运行时尺寸矩阵在标准 C++ 中的朴素表达，并自然引出 `std::span` 等后续学习方向。

### 📄 变更文件

- `documents/vol1-fundamentals/ch05/01-c-arrays.md`（+131 / −2，仅此一个文件）

## 作者与授权

- 作者署名：xiaoshuaijie
- 是否原创：是
- 是否允许维护者调整标题、格式、放置位置和部分措辞：允许
- 外部资料、图片、代码来源：无外部材料；代码为本 PR 原创，文中关于 VLA 的标准状态（C99 引入 / C11 起可选 / 非标准 C++）已按仓库金科玉律用 gcc / g++ 实测验证，见下文测试一节。

## 建议位置

保持原位：`documents/vol1-fundamentals/ch05/01-c-arrays.md`。不涉及新文章收录，无需更新导航或索引。

## 测试

测试环境：WSL2（Ubuntu 24.04，内核 `6.6.87.2-microsoft-standard-WSL2`），编译器 `g++/gcc 13.3.0 (Ubuntu 13.3.0-6ubuntu2~24.04.1)`。

- 三个练习的答案代码均用 `-std=c++17 -Wall -Wextra` 实际编译，零警告，运行结果与文中标注一致：
  - 练习一输出 `总和: 55` / `平均值: 5.5`；
  - 练习二固定尺寸与一维展开两种写法均另配测试 `main` 验证，2×3 转置结果正确输出 `1 4 / 2 5 / 3 6`；
  - 练习三修复后输出 `10 20 30 40 50`，无越界。
- VLA 论断做了双向验证：VLA 版本用 `gcc -std=c99` 编译运行通过（印证"C99 特性"），同一份代码用 `g++ -std=c++17 -pedantic-errors` 编译报错 `use of parameter outside function body`（印证"不是标准 C++"）。
- 全仓 frontmatter 校验通过：`.venv python scripts/validate_frontmatter.py` → 991/991 valid。
- `markdownlint documents/vol1-fundamentals/ch05/01-c-arrays.md` 0 错误。
- `::: details` 折叠块为 VitePress 支持语法，站点渲染正常，与 #201/#206/#207 同类 PR 格式一致。

## 检查项

- [x] Markdown 可以正常阅读
- [x] 引用外部资料时已提供来源（C99/C11 VLA 标准状态经编译实测验证）
- [x] 图片、代码或大段材料来源清楚（均为本 PR 原创代码）
- [x] 如包含代码，已说明是否测试过（见"测试"一节）
- [x] 如申请进入正式教程，已考虑是否需要更新导航或索引（不涉及，保持原文章原位置）
- [x] 如涉及英文翻译，已说明是否同步（不涉及）

## 关联 Issue / Discussion

Close #

Related #