### PR TITLE
docs(cpp): 补全析构函数与资源管理章节练习答案

### DIFF
--- a/documents/vol1-fundamentals/ch06/03-destructors.md
+++ b/documents/vol1-fundamentals/ch06/03-destructors.md
@@ -11,7 +11,7 @@ order: 3
 platform: host
 prerequisites:
 - 构造函数
-reading_time_minutes: 10
+reading_time_minutes: 17
 tags:
 - cpp-modern
 - host
@@ -372,9 +372,180 @@ cat raii_demo.txt
 
 ## 练习
 
-**练习 1：作用域日志计时器**。写一个 `ScopedLogger` 类，构造时记录时间戳（格式 `HH:MM:SS`），析构时打印"elapsed X seconds"。提示：使用 `<ctime>` 中的 `std::time` 和 `std::localtime`。
+### 练习 1：作用域日志计时器
 
-**练习 2：简易文件句柄**。实现一个 `FileHandle` 类，构造时打开文件，析构时自动关闭。提供 `read_line()` 方法（返回 `std::string`）和 `is_valid()` 方法。用 Rule of Three 的思路想想：这个类需要禁用拷贝吗？为什么？
+写一个 `ScopedLogger` 类，构造时记录时间戳（格式 `HH:MM:SS`），析构时打印"elapsed X seconds"。提示：使用 `<ctime>` 中的 `std::time` 和 `std::localtime`。
+
+::: details 参考答案
+
+```cpp
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+
+class ScopedLogger
+{
+private:
+    std::time_t start_time_;
+    std::time_t end_time_;
+
+public:
+    ScopedLogger()
+    {
+        start_time_ = std::time(nullptr);
+        std::tm *local_time = std::localtime(&start_time_);
+        std::cout << "Start time: "
+                  << std::setfill('0') << std::setw(2) << local_time->tm_hour
+                  << ":"
+                  << std::setfill('0') << std::setw(2) << local_time->tm_min
+                  << ":"
+                  << std::setfill('0') << std::setw(2) << local_time->tm_sec
+                  << std::endl;
+    }
+    ~ScopedLogger()
+    {
+        end_time_ = std::time(nullptr);
+        std::cout << "elapsed "
+                  << (end_time_ - start_time_)
+                  << " seconds"
+                  << std::endl;
+    }
+    ScopedLogger(const ScopedLogger &) = delete;
+    ScopedLogger &operator=(const ScopedLogger &) = delete;
+};
+
+int main()
+{
+    ScopedLogger logger;
+
+    for (int i = 0; i < 100000000; ++i)
+    {
+        for (int i = 0; i < 100; ++i)
+        {
+        }
+    }
+
+    return 0;
+}
+```
+
+编译运行：
+
+```bash
+g++ -std=c++17 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果：
+
+```text
+Start time: 20:29:39
+elapsed 4 seconds
+```
+
+> 小技巧：`std::setfill('0')` 配合 `std::setw(2)` 可以让时分秒在不足两位时自动补 `0`，比如 `9:5:3` 会显示为 `09:05:03`。
+
+:::
+
+### 练习 2：简易文件句柄
+
+实现一个 `FileHandle` 类，构造时打开文件，析构时自动关闭。提供 `read_line()` 方法（返回 `std::string`）和 `is_valid()` 方法。用 Rule of Three 的思路想想：这个类需要禁用拷贝吗？为什么？
+
+::: details 参考答案
+
+```cpp
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+class FileHandle
+{
+private:
+    FILE *handle;
+
+public:
+    // 构造：打开文件
+    FileHandle(const char *filename)
+    {
+        handle = fopen(filename, "r");
+    }
+
+    // 析构：关闭文件
+    ~FileHandle()
+    {
+        if (handle != nullptr)
+        {
+            fclose(handle);
+        }
+    }
+
+    // 读取一行
+    std::string read_line()
+    {
+        char buffer[256];
+
+        if (fgets(buffer, sizeof(buffer), handle) != nullptr)
+        {
+            return std::string(buffer);
+        }
+
+        return {};
+    }
+
+    // 判断文件是否打开成功
+    bool is_valid() const
+    {
+        return handle != nullptr;
+    }
+
+    // 禁止拷贝
+    FileHandle(const FileHandle &) = delete;
+    FileHandle &operator=(const FileHandle &) = delete;
+};
+
+int main()
+{
+    FileHandle file("test.txt");
+
+    // 判断文件是否打开成功
+    if (!file.is_valid())
+    {
+        std::cout << "open file failed" << std::endl;
+        return 1;
+    }
+
+    // 读取第一行
+    std::cout << file.read_line();
+
+    // 读取第二行
+    std::cout << file.read_line();
+
+    return 0;
+}
+```
+
+准备一个测试用的 `test.txt`：
+
+```text
+Hello from line 1
+Hello from line 2
+```
+
+编译运行：
+
+```bash
+g++ -std=c++17 -Wall -Wextra main.cpp -o main && ./main
+```
+
+运行结果：
+
+```text
+Hello from line 1
+Hello from line 2
+```
+
+> 关于练习里的追问：这个类**需要禁用拷贝**。`FileHandle` 持有裸 `FILE*` 资源，编译器默认生成的拷贝操作只做浅拷贝——两个对象的 `handle` 指向同一个 `FILE*`，作用域结束时会对同一个句柄 `fclose` 两次，属于未定义行为。这正是本章 Rule of Three 的应用场景：手写了析构函数，就必须同时审视拷贝语义——要么实现深拷贝，要么像这里一样直接禁止拷贝。
+
+:::
 
 ## 小结
 


### PR DESCRIPTION
## 投稿类型

- [ ] 社区来稿初刊：希望先进入 `documents/community/incoming/`
- [x] 现有文章改进
- [ ] 翻译或双语同步
- [ ] 其他

## 文章说明

### 背景

`vol1-fundamentals/ch06`（类与对象）正在逐篇补全练习参考答案，前两篇已完成：

- #227 补全《类的定义》（01-class-basics.md）
- #228 补全《构造函数》（02-constructors.md）

本 PR 延续同样的格式，为第三篇《析构函数与资源管理》（03-destructors.md）补全练习 1、练习 2 的参考答案。

### 新增内容

- **练习 1 · 作用域日志计时器**：`ScopedLogger` 类，构造时用 `std::time` + `std::localtime` 打印 `HH:MM:SS` 时间戳，析构时打印 `elapsed X seconds`；禁用拷贝。输出后以「小技巧」引用块说明 `std::setfill('0')` + `std::setw(2)` 的补零写法。
- **练习 2 · 简易文件句柄**：`FileHandle` 类，构造 `fopen` / 析构 `fclose`，提供 `read_line()` 与 `is_valid()`；禁用拷贝；附测试输入文件 `test.txt`。输出后以引用块回答题目追问「这个类需要禁用拷贝吗？为什么？」——类持有裸 `FILE*`，编译器默认生成的浅拷贝会让两个对象析构时对同一句柄重复 `fclose`（未定义行为），正好落地本章 Rule of Three 的知识点。

两段答案均为完整可编译程序，附编译命令与真实运行输出；呈现格式（`::: details` 折叠块、Allman 大括号、「编译运行：/运行结果：」小节、`text` 输出块、输出后引用块补充说明）与 #227 / #228 保持一致。

### 格式规范自查

| 项目 | 处理 |
|---|---|
| 练习标题 | `### 练习 N：` 三级标题（与 01/02 篇一致） |
| include | 组内字母序排列，类定义前空行 |
| 标点 | 「编译运行：」「运行结果：」全角冒号，与正文一致 |
| 编译命令 | `g++ -std=c++17 -Wall -Wextra main.cpp -o main && ./main` |
| 输出 | `text` 围栏标注，均为真实运行输出 |
| 代码结构 | 类定义与 `int main()` 之间空行；`main` 末尾 `return 0;` |

### 其他

- `reading_time_minutes: 10 → 17`（按补全答案后的全文长度重估）。
- 仅改动单篇文章内容，无需更新导航或索引。

## 验证方式

- [x] Markdown 可以正常阅读
- [x] 如包含代码，已说明是否测试过：两段答案以 `g++ -std=c++17 -Wall -Wextra` 编译**零告警**，运行输出与文中一致（练习 1 的日期时间与耗时随机器不同属正常现象）；`test.txt` 围栏等附属内容已核对
- [x] Frontmatter 校验通过：`.venv/Scripts/python.exe scripts/validate_frontmatter.py` 全仓 997 valid / 0 errors / 0 warnings
- 本机环境：Windows 11，g++ 8.1.0（MinGW-w64 x86_64）

## 关联 Issue / Discussion

Related #227 #228